### PR TITLE
feat(frontend): rediseño profesional de la página Agentes

### DIFF
--- a/front/front/src/pages/Agentes.jsx
+++ b/front/front/src/pages/Agentes.jsx
@@ -1,291 +1,382 @@
 import React, { useState, useEffect } from "react";
 import { useAgents } from "../context/AgentContext";
-import { Monitor, Wifi, WifiOff, Activity, Calendar, Server, Globe } from "lucide-react";
+import {
+  Monitor,
+  Wifi,
+  WifiOff,
+  Activity,
+  Server,
+  Globe,
+  Clock,
+  RefreshCw,
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  Cpu,
+} from "lucide-react";
+
+// ─── Paleta ───────────────────────────────────────────────────────────────────
+const BG    = "#0d1117";
+const CARD  = "#161b22";
+const BORDER = "#21262d";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function osIcon(os = "") {
+  const l = os.toLowerCase();
+  if (l.includes("windows")) return { glyph: "⊞", color: "#58a6ff" };
+  if (l.includes("darwin") || l.includes("mac")) return { glyph: "", color: "#d2a8ff" };
+  return { glyph: "🐧", color: "#3fb950" };
+}
+
+function relativeTime(dateStr) {
+  const diff = Math.floor((Date.now() - new Date(dateStr)) / 1000);
+  if (diff < 60)  return `hace ${diff}s`;
+  if (diff < 3600) return `hace ${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `hace ${Math.floor(diff / 3600)}h`;
+  return `hace ${Math.floor(diff / 86400)}d`;
+}
+
+// ─── Sub-componentes ──────────────────────────────────────────────────────────
+
+function StatusPill({ connected, active }) {
+  if (connected && active)
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1 rounded-full"
+        style={{ background: "rgba(63,185,80,0.15)", color: "#3fb950", border: "1px solid rgba(63,185,80,0.3)" }}>
+        <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+        ACTIVO
+      </span>
+    );
+  if (connected)
+    return (
+      <span className="flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1 rounded-full"
+        style={{ background: "rgba(88,166,255,0.15)", color: "#58a6ff", border: "1px solid rgba(88,166,255,0.3)" }}>
+        <span className="w-1.5 h-1.5 rounded-full bg-blue-400" />
+        CONECTADO
+      </span>
+    );
+  return (
+    <span className="flex items-center gap-1.5 text-xs font-semibold px-2.5 py-1 rounded-full"
+      style={{ background: "rgba(110,118,129,0.15)", color: "#6e7681", border: "1px solid rgba(110,118,129,0.3)" }}>
+      <span className="w-1.5 h-1.5 rounded-full bg-gray-500" />
+      OFFLINE
+    </span>
+  );
+}
+
+function AgentCard({ agent, pulse = false }) {
+  const icon = osIcon(agent.OS);
+  const borderColor = agent.Connected && agent.Active
+    ? "#238636"
+    : agent.Connected
+    ? "#1f6feb"
+    : "#30363d";
+
+  return (
+    <div
+      className="rounded-xl border overflow-hidden transition-all duration-200 hover:translate-y-[-2px]"
+      style={{ background: CARD, borderColor: BORDER, borderLeft: `3px solid ${borderColor}` }}
+    >
+      <div className="p-5">
+        {/* Cabecera */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div
+              className="w-10 h-10 rounded-lg flex items-center justify-center text-xl shrink-0"
+              style={{ background: "#21262d" }}
+            >
+              {icon.glyph}
+            </div>
+            <div className="min-w-0">
+              <h3 className="font-semibold text-sm truncate" style={{ color: "#e6edf3" }}>
+                {agent.Hostname}
+              </h3>
+              <p className="text-xs font-mono truncate mt-0.5" style={{ color: icon.color }}>
+                {agent.OS}
+              </p>
+            </div>
+          </div>
+          <StatusPill connected={agent.Connected} active={agent.Active} />
+        </div>
+
+        {/* Datos */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1.5" style={{ color: "#6e7681" }}>
+              <Globe size={11} /> IP
+            </span>
+            <span className="font-mono px-2 py-0.5 rounded" style={{ color: "#e6edf3", background: "#0d1117" }}>
+              {agent.IP}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1.5" style={{ color: "#6e7681" }}>
+              <Clock size={11} /> Última vez
+            </span>
+            <span style={{ color: "#8b949e" }}>{relativeTime(agent.LastSeen)}</span>
+          </div>
+        </div>
+
+        {/* UUID */}
+        <div
+          className="mt-3 px-2 py-1.5 rounded text-xs font-mono truncate"
+          style={{ background: "#0d1117", color: "#484f58" }}
+        >
+          {agent.UUID}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-xl border p-5 animate-pulse" style={{ background: CARD, borderColor: BORDER }}>
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 rounded-lg" style={{ background: "#21262d" }} />
+        <div className="flex-1 space-y-2">
+          <div className="h-3 w-28 rounded" style={{ background: "#21262d" }} />
+          <div className="h-2.5 w-20 rounded" style={{ background: "#21262d" }} />
+        </div>
+      </div>
+      <div className="space-y-2.5">
+        <div className="h-2.5 w-full rounded" style={{ background: "#21262d" }} />
+        <div className="h-2.5 w-3/4 rounded" style={{ background: "#21262d" }} />
+        <div className="h-6 w-full rounded mt-3" style={{ background: "#21262d" }} />
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ icon: Icon, label, value, color }) {
+  return (
+    <div className="flex items-center gap-3 px-5 py-4 rounded-xl border" style={{ background: CARD, borderColor: BORDER }}>
+      <div className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
+        style={{ background: `${color}18`, border: `1px solid ${color}30` }}>
+        <Icon size={16} style={{ color }} />
+      </div>
+      <div>
+        <p className="text-xs" style={{ color: "#6e7681" }}>{label}</p>
+        <p className="text-xl font-bold font-mono" style={{ color: "#e6edf3" }}>{value}</p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Componente principal ─────────────────────────────────────────────────────
 
 const Agentes = () => {
   const agents = useAgents();
   const [allAgents, setAllAgents] = useState([]);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState(null);
+  const [lastUpdate, setLastUpdate] = useState(null);
   const pageSize = 6;
 
-  useEffect(() => {
-    const fetchAllAgents = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const response = await fetch('http://localhost:5000/agents');
-        if (!response.ok) {
-          throw new Error(`Error ${response.status}: ${response.statusText}`);
-        }
-        const data = await response.json();
-        setAllAgents(data);
-      } catch (err) {
-        console.error('Error fetching all agents:', err);
-        setError(err.message);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchAllAgents();
-    const interval = setInterval(fetchAllAgents, 30000);
-    return () => clearInterval(interval);
-  }, []);
-
-  const activeAgents = agents.filter((a) => a.Connected && a.Active);
-  const paginatedAgents = allAgents.slice((page - 1) * pageSize, page * pageSize);
-  const totalPages = Math.ceil(allAgents.length / pageSize);
-
-  const StatusBadge = ({ connected, active }) => {
-    if (connected && active) {
-      return (
-        <div className="flex items-center gap-1">
-          <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></div>
-          <span className="text-xs font-medium text-emerald-700 bg-emerald-100 px-2 py-1 rounded-full">
-            Activo
-          </span>
-        </div>
-      );
-    } else if (connected) {
-      return (
-        <div className="flex items-center gap-1">
-          <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-          <span className="text-xs font-medium text-blue-700 bg-blue-100 px-2 py-1 rounded-full">
-            Conectado
-          </span>
-        </div>
-      );
-    } else {
-      return (
-        <div className="flex items-center gap-1">
-          <div className="w-2 h-2 bg-gray-400 rounded-full"></div>
-          <span className="text-xs font-medium text-gray-600 bg-gray-100 px-2 py-1 rounded-full">
-            Offline
-          </span>
-        </div>
-      );
+  const fetchAll = async (isManual = false) => {
+    if (isManual) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("http://localhost:5000/agents");
+      if (!res.ok) throw new Error(`Error ${res.status}: ${res.statusText}`);
+      const data = await res.json();
+      setAllAgents(data);
+      setLastUpdate(new Date());
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
     }
   };
 
-  const AgentCard = ({ agent, isActive = false }) => (
-    <div className={`group relative bg-white rounded-xl shadow-sm border transition-all duration-300 hover:shadow-lg hover:-translate-y-1 ${
-      isActive ? 'border-emerald-200 bg-gradient-to-br from-emerald-50 to-white' : 'border-gray-200 hover:border-gray-300'
-    }`}>
-      <div className="p-6">
-        <div className="flex items-start justify-between mb-4">
+  useEffect(() => {
+    fetchAll();
+    const iv = setInterval(() => fetchAll(), 30000);
+    return () => clearInterval(iv);
+  }, []);
+
+  const activeAgents = agents.filter((a) => a.Connected && a.Active);
+  const connectedAgents = agents.filter((a) => a.Connected);
+  const offlineCount = Math.max(0, allAgents.length - connectedAgents.length);
+  const paginatedAgents = allAgents.slice((page - 1) * pageSize, page * pageSize);
+  const totalPages = Math.ceil(allAgents.length / pageSize);
+
+  return (
+    <div className="min-h-full" style={{ background: BG }}>
+
+      {/* ── Header sticky ── */}
+      <div
+        className="sticky top-0 z-10 px-6 py-4 border-b"
+        style={{ background: `${BG}e8`, borderColor: BORDER, backdropFilter: "blur(8px)" }}
+      >
+        <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className={`p-3 rounded-lg ${
-              agent.Connected && agent.Active 
-                ? 'bg-emerald-100 text-emerald-600' 
-                : agent.Connected 
-                ? 'bg-blue-100 text-blue-600'
-                : 'bg-gray-100 text-gray-500'
-            }`}>
-              <Monitor className="w-5 h-5" />
-            </div>
+            <Activity size={18} style={{ color: "#58a6ff" }} />
             <div>
-              <h3 className="font-semibold text-gray-900 group-hover:text-gray-700 transition-colors">
-                {agent.Hostname}
-              </h3>
-              <p className="text-sm text-gray-500 flex items-center gap-1">
-                <Server className="w-3 h-3" />
-                {agent.OS}
+              <h1 className="text-base font-bold" style={{ color: "#e6edf3" }}>
+                Panel de Agentes
+              </h1>
+              <p className="text-xs" style={{ color: "#6e7681" }}>
+                Monitoreo en tiempo real
               </p>
             </div>
           </div>
-          <StatusBadge connected={agent.Connected} active={agent.Active} />
-        </div>
-        
-        <div className="space-y-3">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600 flex items-center gap-1">
-              <Globe className="w-3 h-3" />
-              IP Address
-            </span>
-            <span className="font-mono text-gray-900 bg-gray-50 px-2 py-1 rounded">
-              {agent.IP}
-            </span>
-          </div>
-          
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600 flex items-center gap-1">
-              <Calendar className="w-3 h-3" />
-              Última conexión
-            </span>
-            <span className="text-gray-700">
-              {new Date(agent.LastSeen).toLocaleDateString('es-ES', {
-                day: '2-digit',
-                month: 'short',
-                hour: '2-digit',
-                minute: '2-digit'
-              })}
-            </span>
-          </div>
-        </div>
-      </div>
-      
-      {isActive && (
-        <div className="absolute top-2 right-2">
-          <div className="w-3 h-3 bg-emerald-500 rounded-full animate-pulse shadow-lg"></div>
-        </div>
-      )}
-    </div>
-  );
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 sticky top-0 z-10 backdrop-blur-sm bg-white/95">
-        <div className="max-w-7xl mx-auto px-6 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
-                <Activity className="w-8 h-8 text-emerald-600" />
-                Panel de Agentes
-              </h1>
-              <p className="text-gray-600 mt-1">Monitoreo en tiempo real de agentes conectados</p>
-            </div>
-            <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2 bg-emerald-50 px-4 py-2 rounded-lg">
-                <div className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></div>
-                <span className="text-sm font-medium text-emerald-700">
-                  {activeAgents.length} Activos
-                </span>
-              </div>
-              <div className="flex items-center gap-2 bg-gray-50 px-4 py-2 rounded-lg">
-                <Server className="w-4 h-4 text-gray-600" />
-                <span className="text-sm font-medium text-gray-700">
-                  {allAgents.length} Total
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="max-w-7xl mx-auto px-6 py-8">
-        {/* Agentes Activos */}
-        <section className="mb-12">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="p-2 bg-emerald-100 rounded-lg">
-              <Wifi className="w-5 h-5 text-emerald-600" />
-            </div>
-            <h2 className="text-2xl font-bold text-gray-900">
-              Agentes Activos
-              <span className="ml-2 text-lg font-normal text-gray-500">
-                ({activeAgents.length})
+          <div className="flex items-center gap-3">
+            {lastUpdate && (
+              <span className="text-xs font-mono hidden sm:block" style={{ color: "#484f58" }}>
+                Actualizado {lastUpdate.toLocaleTimeString()}
               </span>
-            </h2>
+            )}
+            <button
+              onClick={() => fetchAll(true)}
+              disabled={refreshing}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+              style={{ background: "#21262d", color: "#8b949e", border: `1px solid ${BORDER}` }}
+            >
+              <RefreshCw size={11} className={refreshing ? "animate-spin" : ""} />
+              Actualizar
+            </button>
           </div>
-          
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-6 py-6 space-y-8">
+
+        {/* ── Stats ── */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <StatCard icon={Wifi}       label="Activos"    value={activeAgents.length}    color="#3fb950" />
+          <StatCard icon={Monitor}    label="Conectados" value={connectedAgents.length}  color="#58a6ff" />
+          <StatCard icon={Server}     label="Total"      value={allAgents.length}        color="#d29922" />
+          <StatCard icon={WifiOff}    label="Offline"    value={offlineCount}            color="#6e7681" />
+        </div>
+
+        {/* ── Error ── */}
+        {error && (
+          <div
+            className="flex items-start gap-3 px-5 py-4 rounded-xl border text-sm"
+            style={{ background: "rgba(248,81,73,0.08)", borderColor: "#f851494d", color: "#ffa198" }}
+          >
+            <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+            <div>
+              <p className="font-medium">Error de conexión</p>
+              <p className="text-xs mt-0.5 opacity-75">{error}</p>
+            </div>
+          </div>
+        )}
+
+        {/* ── Agentes Activos (WebSocket live) ── */}
+        <section>
+          <div className="flex items-center gap-2 mb-4">
+            <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: "#3fb950" }}>
+              En vivo
+            </h2>
+            <span
+              className="text-xs font-mono px-2 py-0.5 rounded-full"
+              style={{ background: "rgba(63,185,80,0.15)", color: "#3fb950", border: "1px solid rgba(63,185,80,0.3)" }}
+            >
+              {activeAgents.length}
+            </span>
+          </div>
+
           {activeAgents.length === 0 ? (
-            <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
-              <WifiOff className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No hay agentes activos</h3>
-              <p className="text-gray-600">Los agentes conectados aparecerán aquí en tiempo real</p>
+            <div
+              className="flex flex-col items-center justify-center py-12 rounded-xl border"
+              style={{ background: CARD, borderColor: BORDER }}
+            >
+              <WifiOff size={32} style={{ color: "#30363d" }} className="mb-3" />
+              <p className="text-sm" style={{ color: "#6e7681" }}>No hay agentes activos</p>
+              <p className="text-xs mt-1" style={{ color: "#484f58" }}>Los agentes en vivo aparecerán aquí</p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {activeAgents.map((agent) => (
-                <AgentCard key={agent.UUID} agent={agent} isActive={true} />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {activeAgents.map((a) => (
+                <AgentCard key={a.UUID} agent={a} pulse />
               ))}
             </div>
           )}
         </section>
 
-        {/* Todos los Agentes */}
+        {/* ── Historial ── */}
         <section>
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-blue-100 rounded-lg">
-                <Server className="w-5 h-5 text-blue-600" />
-              </div>
-              <h2 className="text-2xl font-bold text-gray-900">
-                Historial de Agentes
-                <span className="ml-2 text-lg font-normal text-gray-500">
-                  ({allAgents.length})
-                </span>
-              </h2>
-              {loading && (
-                <div className="flex items-center gap-2 text-blue-600">
-                  <div className="w-4 h-4 border-2 border-blue-600 border-t-transparent rounded-full animate-spin"></div>
-                  <span className="text-sm font-medium">Actualizando...</span>
-                </div>
-              )}
-            </div>
+          <div className="flex items-center gap-2 mb-4">
+            <Cpu size={13} style={{ color: "#58a6ff" }} />
+            <h2 className="text-sm font-semibold uppercase tracking-widest" style={{ color: "#58a6ff" }}>
+              Historial de Agentes
+            </h2>
+            <span
+              className="text-xs font-mono px-2 py-0.5 rounded-full"
+              style={{ background: "rgba(88,166,255,0.12)", color: "#58a6ff", border: "1px solid rgba(88,166,255,0.25)" }}
+            >
+              {allAgents.length}
+            </span>
           </div>
-          
-          {error && (
-            <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-6">
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-5 h-5 bg-red-500 rounded-full flex items-center justify-center">
-                  <span className="text-white text-xs font-bold">!</span>
-                </div>
-                <h3 className="font-semibold text-red-800">Error de conexión</h3>
-              </div>
-              <p className="text-red-700 mb-2">{error}</p>
-              <p className="text-sm text-red-600">
-                Verifica que el servidor esté ejecutándose en http://localhost:5000
-              </p>
-            </div>
-          )}
 
+          {/* Skeletons */}
           {loading && allAgents.length === 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {[...Array(6)].map((_, i) => (
-                <div key={i} className="bg-white rounded-xl border border-gray-200 p-6 animate-pulse">
-                  <div className="flex items-center gap-3 mb-4">
-                    <div className="w-11 h-11 bg-gray-200 rounded-lg"></div>
-                    <div className="flex-1">
-                      <div className="w-24 h-4 bg-gray-200 rounded mb-2"></div>
-                      <div className="w-16 h-3 bg-gray-200 rounded"></div>
-                    </div>
-                  </div>
-                  <div className="space-y-3">
-                    <div className="w-full h-3 bg-gray-200 rounded"></div>
-                    <div className="w-3/4 h-3 bg-gray-200 rounded"></div>
-                  </div>
-                </div>
-              ))}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {[...Array(6)].map((_, i) => <SkeletonCard key={i} />)}
             </div>
           ) : paginatedAgents.length === 0 ? (
-            <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
-              <Server className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">
-                {error ? 'Error al cargar agentes' : 'No hay agentes registrados'}
-              </h3>
-              <p className="text-gray-600">
-                {error ? 'Revisa la conexión al servidor' : 'Los agentes registrados aparecerán aquí'}
+            <div
+              className="flex flex-col items-center justify-center py-12 rounded-xl border"
+              style={{ background: CARD, borderColor: BORDER }}
+            >
+              <Server size={32} style={{ color: "#30363d" }} className="mb-3" />
+              <p className="text-sm" style={{ color: "#6e7681" }}>
+                {error ? "Error al cargar agentes" : "No hay agentes registrados"}
               </p>
             </div>
           ) : (
             <>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {paginatedAgents.map((agent) => (
-                  <AgentCard key={agent.UUID} agent={agent} />
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {paginatedAgents.map((a) => (
+                  <AgentCard key={a.UUID} agent={a} />
                 ))}
               </div>
 
               {/* Paginación */}
               {totalPages > 1 && (
-                <div className="flex justify-center mt-8">
-                  <div className="flex items-center gap-2 bg-white rounded-lg border border-gray-200 p-1">
-                    {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
-                      <button
-                        key={n}
-                        onClick={() => setPage(n)}
-                        className={`px-4 py-2 rounded-md text-sm font-medium transition-all ${
-                          page === n
-                            ? "bg-gray-900 text-white shadow-sm"
-                            : "text-gray-700 hover:bg-gray-50 hover:text-gray-900"
-                        }`}
-                      >
-                        {n}
-                      </button>
-                    ))}
-                  </div>
+                <div className="flex items-center justify-center gap-2 mt-6">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="p-2 rounded-lg border transition-colors disabled:opacity-30"
+                    style={{ background: "#21262d", borderColor: BORDER, color: "#8b949e" }}
+                  >
+                    <ChevronLeft size={14} />
+                  </button>
+
+                  {Array.from({ length: totalPages }, (_, i) => i + 1).map((n) => (
+                    <button
+                      key={n}
+                      onClick={() => setPage(n)}
+                      className="w-8 h-8 rounded-lg border text-xs font-mono font-medium transition-all"
+                      style={{
+                        background: page === n ? "#388bfd" : "#21262d",
+                        borderColor: page === n ? "#388bfd" : BORDER,
+                        color: page === n ? "#ffffff" : "#8b949e",
+                      }}
+                    >
+                      {n}
+                    </button>
+                  ))}
+
+                  <button
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page === totalPages}
+                    className="p-2 rounded-lg border transition-colors disabled:opacity-30"
+                    style={{ background: "#21262d", borderColor: BORDER, color: "#8b949e" }}
+                  >
+                    <ChevronRight size={14} />
+                  </button>
                 </div>
               )}
             </>


### PR DESCRIPTION
- Tema oscuro completo (GitHub Dark) consistente con el resto del frontend
- Stats bar con 4 tarjetas: Activos / Conectados / Total / Offline
- AgentCard con borde izquierdo de color según estado (verde/azul/gris), ícono de OS, tiempo relativo ("hace Xm") y UUID en mono al pie
- StatusPill con pill coloreado y dot animado para estado ACTIVO
- Header sticky con blur, contador de última actualización y botón Refresh
- Skeletons oscuros animados durante la carga inicial
- Paginación rediseñada con botones ChevronLeft/Right y página activa en azul
- Sección "En vivo" (WebSocket) separada visualmente de "Historial"

https://claude.ai/code/session_01V1k4RrHheNM9Q3V4KUHMpB