### PR TITLE
fix(frontend): evitar crash cuando /agents retorna null en vez de []

### DIFF
--- a/front/front/src/pages/Agentes.jsx
+++ b/front/front/src/pages/Agentes.jsx
@@ -185,7 +185,7 @@ const Agentes = () => {
       const res = await fetch("http://localhost:5000/agents");
       if (!res.ok) throw new Error(`Error ${res.status}: ${res.statusText}`);
       const data = await res.json();
-      setAllAgents(data);
+      setAllAgents(Array.isArray(data) ? data : []);
       setLastUpdate(new Date());
     } catch (err) {
       setError(err.message);


### PR DESCRIPTION
El backend retorna null cuando no hay agentes registrados. setAllAgents(null) reemplazaba el estado inicial [] causando TypeError: Cannot read properties of null (reading 'length').

https://claude.ai/code/session_01V1k4RrHheNM9Q3V4KUHMpB