### PR TITLE
fix(frontend): corregir fetch de reporte y agregar proxy Vite

### DIFF
--- a/front/front/src/pages/ReportDetails.jsx
+++ b/front/front/src/pages/ReportDetails.jsx
@@ -523,9 +523,9 @@ export default function ReportDetails() {
   const [rawOpen, setRawOpen] = useState(false);
 
   useEffect(() => {
-    fetch(`/api/audit/${id}`)
+    fetch(`/api/v1/reports/${id}`)
       .then(r => r.json())
-      .then(d => { setReport(d); setLoading(false); })
+      .then(d => { setReport(d.data ?? d); setLoading(false); })
       .catch(() => setLoading(false));
   }, [id]);
 

--- a/front/front/vite.config.js
+++ b/front/front/vite.config.js
@@ -7,4 +7,11 @@ export default defineConfig({
   plugins: [react(),
     tailwindcss()
   ],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000',
+      '/ws':  { target: 'ws://localhost:5000', ws: true },
+      '/audit': 'http://localhost:5000',
+    }
+  }
 })


### PR DESCRIPTION
- ReportDetails.jsx: URL correcta /api/v1/reports/:id (antes /api/audit/:id) y acceder a response.data ya que el backend envuelve en { success, data }
- vite.config.js: agregar proxy para /api, /ws y /audit hacia localhost:5000 (sin proxy el fetch llegaba al servidor Vite en lugar del backend Go)